### PR TITLE
Refac(SQL Integration) : Close database connection in Get User details method and Delete user method

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SQLIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SQLIntegration.cs
@@ -196,6 +196,7 @@ public class SQLIntegration : IIntegrationBase
         var dbConn = DbConnectionFactory.Create(connection);
         var command = dbConn.CreateCommand(storedProcedureName, parameters);
         await command.ExecuteNonQueryAsync();
+        await connection.CloseAsync();
     }
 
     public async Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, string correlationId, CancellationToken cancellationToken = default)
@@ -234,6 +235,8 @@ public class SQLIntegration : IIntegrationBase
         {
             throw new HttpResponseException(System.Net.HttpStatusCode.NotFound);
         }
+
+        await connection.CloseAsync();
 
         return new Core2EnterpriseUser
         {

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SQLIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SQLIntegration.cs
@@ -234,15 +234,17 @@ public class SQLIntegration : IIntegrationBase
         if (!reader.HasRows)
         {
             throw new HttpResponseException(System.Net.HttpStatusCode.NotFound);
-        }
+        }        
 
-        await connection.CloseAsync();
-
-        return new Core2EnterpriseUser
+        var results = new Core2EnterpriseUser
         {
             Identifier = GetUserInfoFromReader(reader, appConfig, "Identifier"),
             UserName = GetUserInfoFromReader(reader, appConfig, "UserName"),
         };
+
+        await connection.CloseAsync();
+
+        return results;
     }
 
     private static void ValidateAttributeSchema(IList<AttributeSchema> schema)


### PR DESCRIPTION
This pull request includes changes to the `SQLIntegration` class in the `KN.KloudIdentity.Mapper` project to ensure proper resource management by closing database connections asynchronously after usage.

### Resource management improvements:
* Added `await connection.CloseAsync();` to the `DeleteAsync` method to close the database connection after executing a command.
* Added `await connection.CloseAsync();` to the `GetAsync` method to close the database connection after handling a `NotFound` exception.