### PR TITLE
Streamline Deployment & Docker Compatibility: Release-Based Triggers, Config Enhancements, and .NET 8 Migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,8 @@
 name: Project Deployment
 
 on:
-  push:
-    branches: ["main", "dev","ci-cd-pipeline"]
-  pull_request:
-    branches: ["main", "dev","ci-cd-pipeline"]
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -26,22 +24,16 @@ jobs:
       - name: Login to ACR
         run: docker login crkloudidentity.azurecr.io -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }}
 
-      # Get short SHA
-      - name: Set Short SHA
-        id: vars
-        run: echo "short_sha=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
-
-      # Sanitized Ref Name
-      - name: Sanitized Ref Name
-        id: refname
-        run: echo "sanitized_ref_name=$(echo $GITHUB_REF_NAME | sed 's|/|-|g')" >> $GITHUB_ENV
+      # Extract version tag
+      - name: Extract version tag
+        id: version
+        run: echo "version=${{github.event.release.tag_name}}" >> $GITHUB_ENV
 
       # Build the .NET backend Docker image
       - name: Build Docker Image
-        run: docker build --progress=plain -t crkloudidentity.azurecr.io/scimconnector-api:latest -f ./dockerfile .
+        run: docker build --progress=plain -t crkloudidentity.azurecr.io/scimconnector-api:${{ env.version }} -f ./dockerfile .
 
       # Push the Docker image to ACR
       - name: Push Docker Image
         run: | 
-          docker push crkloudidentity.azurecr.io/scimconnector-api:latest
-    
+          docker push crkloudidentity.azurecr.io/scimconnector-api:${{ env.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,10 +38,10 @@ jobs:
 
       # Build the .NET backend Docker image
       - name: Build Docker Image
-        run: docker build --progress=plain -t crkloudidentity.azurecr.io/scimconnector-api-1:${{ env.sanitized_ref_name }}-${{ github.run_number }}-${{ env.short_sha }} -f ./dockerfile .
+        run: docker build --progress=plain -t crkloudidentity.azurecr.io/scimconnector-api:latest -f ./dockerfile .
 
       # Push the Docker image to ACR
       - name: Push Docker Image
         run: | 
-          docker push crkloudidentity.azurecr.io/scimconnector-api-1:${{ env.sanitized_ref_name }}-${{ github.run_number }}-${{ env.short_sha }}
+          docker push crkloudidentity.azurecr.io/scimconnector-api:latest
     

--- a/KN.KloudIdentity.MapperTests/Utils/InboundMappingConfigTests.cs
+++ b/KN.KloudIdentity.MapperTests/Utils/InboundMappingConfigTests.cs
@@ -313,8 +313,10 @@ public class InboundMappingConfigTests
         Assert.Equal("D100", result!["Operations"]![0]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["departmentId"]!.ToString());
         Assert.Equal("john.doe@example.com", result!["Operations"]![0]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["email"]!.ToString());
         Assert.Equal(1, result!["Operations"]![0]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["empSequenceNumber"]!.ToObject<int>());
-        Assert.Equal("1/1/2021 12:00:00 AM", result!["Operations"]![0]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["startingDate"]!.ToString());
-
+        Assert.Equal(
+            "1/1/2021 12:00:00 AM",
+            result!["Operations"]![0]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["startingDate"]!.ToString().Replace('\u202F', ' ')
+        );
         Assert.Equal("U002", result!["Operations"]![1]!["data"]!["externalId"]!.ToString());
         Assert.Equal("en-US", result!["Operations"]![0]!["data"]!["preferredLanguage"]!.ToString());
         Assert.Equal("U002", result!["Operations"]![1]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["userId"]!.ToString());
@@ -326,6 +328,9 @@ public class InboundMappingConfigTests
         Assert.Equal("D101", result!["Operations"]![1]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["departmentId"]!.ToString());
         Assert.Equal("jane.smith@example.com", result!["Operations"]![1]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["email"]!.ToString());
         Assert.Equal(2, result!["Operations"]![1]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["empSequenceNumber"]!.ToObject<int>());
-        Assert.Equal("1/1/2023 12:00:00 AM", result!["Operations"]![1]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["startingDate"]!.ToString());
+        Assert.Equal(
+            "1/1/2023 12:00:00 AM",
+            result!["Operations"]![1]!["data"]!["urn:ietf:params:scim:schemas:extension:ki:1.0:User"]!["startingDate"]!.ToString().Replace('\u202F', ' ')
+        );    
     }
 }

--- a/Microsoft.SCIM.WebHostSample/Program.cs
+++ b/Microsoft.SCIM.WebHostSample/Program.cs
@@ -20,28 +20,27 @@ namespace Microsoft.SCIM.WebHostSample
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((hostingContext, config) =>
+                .ConfigureAppConfiguration((hostingContext, config) =>
                 {
+                    config.AddUserSecrets<Program>();
                     var settings = config.Build();
                     config.AddAzureAppConfiguration(options =>
                     {
+                     //   Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
                         options.Connect(settings["ConnectionStrings:AppConfig"])
-                        .Select("KI:*", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development" ? "KloudIdentity-Dev" : "KloudIdentity-Demo")
-                        .ConfigureKeyVault(kv =>
-                        {
-                            kv.SetCredential(new DefaultAzureCredential());
-                        })
-                        .ConfigureRefresh(refresh =>
-                        {
-                            refresh.Register("KI:RefreshOption", refreshAll: true)
-                                .SetCacheExpiration(TimeSpan.FromSeconds(5));
-                        })
-                        .UseFeatureFlags();
+                            .Select("KI:*",
+                                Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development"
+                                    ? "KloudIdentity-Dev"
+                                    : "KloudIdentity-Docker-Local")
+                            .ConfigureKeyVault(kv => { kv.SetCredential(new DefaultAzureCredential()); })
+                            .ConfigureRefresh(refresh =>
+                            {
+                                refresh.Register("KI:RefreshOption", refreshAll: true)
+                                    .SetCacheExpiration(TimeSpan.FromSeconds(5));
+                            })
+                            .UseFeatureFlags();
                     });
                 })
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
     }
 }

--- a/Microsoft.SCIM.WebHostSample/dockerfile
+++ b/Microsoft.SCIM.WebHostSample/dockerfile
@@ -1,22 +1,27 @@
-# Use the official Microsoft .NET Core runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
 
-# Set the working directory in the image to /app
+COPY Microsoft.SCIM.WebHostSample/*.csproj Microsoft.SCIM.WebHostSample/
+RUN dotnet restore Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
+
+COPY . .
+
+WORKDIR /src/Microsoft.SCIM.WebHostSample
+RUN dotnet publish Microsoft.SCIM.WebHostSample.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
+COPY --from=build /app/publish .
 
-# Copy the build output from the outside to /app in the image
-COPY ./bin/Release/net7.0/publish/ .
-
-ARG CONNECTION_STRING_DB
+ARG CONNECTION_STRING_HANGFIRE_DB
 ARG CONNECTION_STRING_APPCONFIG
 
-# Set the environment variable for ASP.NET Core to listen on port 80
 ENV ASPNETCORE_URLS=http://+:80
-ENV ConnectionStrings:DefaultConnection=$CONNECTION_STRING_DB
-ENV ConnectionStrings:AppConfig=$CONNECTION_STRING_APPCONFIG
+ENV ConnectionStrings:HangfireConnection=${CONNECTION_STRING_HANGFIRE_DB}
+ENV ConnectionStrings:AppConfig=${CONNECTION_STRING_APPCONFIG}
 
-# Expose port 80
 EXPOSE 80
 
-# Run the application
 ENTRYPOINT ["dotnet", "Microsoft.SCIM.WebHostSample.dll"]


### PR DESCRIPTION
This pull request introduces changes to streamline deployment workflows, enhance configuration management, and update the Dockerfile for compatibility with .NET 8. Key updates include transitioning to release-based triggers for deployment, refining environment variable handling, and improving the build process in the Dockerfile.

### Deployment Workflow Updates:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L7-R8): Changed deployment trigger from `push` and `pull_request` on branches to `release` events with `published` types. Removed short SHA and sanitized ref name logic, replacing them with version tag extraction from release metadata. Updated Docker image tagging to use the extracted version tag. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L7-R8) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L29-R39)

### Configuration Management Enhancements:
* [`Microsoft.SCIM.WebHostSample/Program.cs`](diffhunk://#diff-2902369b534f8f2d3f982f3c4197be21ccbd17d8b88389113b83055b0cdc8e7cR25-R35): Added user secrets for local development and updated environment variable handling to include a new configuration for `KloudIdentity-Docker-Local`. Simplified `ConfigureWebHostDefaults` method syntax. [[1]](diffhunk://#diff-2902369b534f8f2d3f982f3c4197be21ccbd17d8b88389113b83055b0cdc8e7cR25-R35) [[2]](diffhunk://#diff-2902369b534f8f2d3f982f3c4197be21ccbd17d8b88389113b83055b0cdc8e7cL42-R44)

### Dockerfile Improvements:
* [`Microsoft.SCIM.WebHostSample/dockerfile`](diffhunk://#diff-3c8d811a78161fcea28a5d4041f25424670cc87a182f878ff758e697fca86254L1-L21): Migrated to a multi-stage build process using `.NET SDK 8.0` for the build stage and `.NET ASP.NET 8.0` for the runtime stage. Updated environment variable names and added support for `HangfireConnection` configuration.