### PR TITLE
Add health checks to the application

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Startup.cs
+++ b/Microsoft.SCIM.WebHostSample/Startup.cs
@@ -169,6 +169,7 @@ namespace Microsoft.SCIM.WebHostSample
             services.AddHangfire(x => x.UseSqlServerStorage(configuration["ConnectionStrings:HangfireDBConnection"]));
 
             services.AddHangfireServer();
+            services.AddHealthChecks();
 
             services.AddScoped<NonSCIMGroupProvider>();
             services.AddScoped<NonSCIMUserProvider>();
@@ -207,6 +208,7 @@ namespace Microsoft.SCIM.WebHostSample
                 (IEndpointRouteBuilder endpoints) =>
                 {
                     endpoints.MapDefaultControllerRoute();
+                    endpoints.MapHealthChecks("/api/healthz");
                 });
         }
 


### PR DESCRIPTION
This pull request adds functionality for health checks to the `Microsoft.SCIM.WebHostSample` project. The changes include registering health checks in the service configuration and mapping a new endpoint for health check responses.

### Health Check Integration:

* [`Microsoft.SCIM.WebHostSample/Startup.cs`](diffhunk://#diff-0546088e6af795826c1a116e82707261d2e8cd7007791bd0979678732a52a98fR172): Added `services.AddHealthChecks()` to register health checks in the application's service configuration.
* [`Microsoft.SCIM.WebHostSample/Startup.cs`](diffhunk://#diff-0546088e6af795826c1a116e82707261d2e8cd7007791bd0979678732a52a98fR211): Added `endpoints.MapHealthChecks("/api/healthz")` to define a new endpoint for health check responses.