### PR TITLE
Update Azure Container Registry login and image references

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
        
       # Login to Azure Container Registry
       - name: Login to ACR
-        run: docker login crkloudidentity.azurecr.io -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }}
+        run: docker login acrkidemo-gfazgkhnhdfeamft.azurecr.io -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }}
 
       # Extract version tag
       - name: Extract version tag
@@ -31,9 +31,9 @@ jobs:
 
       # Build the .NET backend Docker image
       - name: Build Docker Image
-        run: docker build --progress=plain -t crkloudidentity.azurecr.io/scimconnector-api:${{ env.version }} -f ./dockerfile .
+        run: docker build --progress=plain -t acrkidemo-gfazgkhnhdfeamft.azurecr.io/scimconnector-api:${{ env.version }} -f ./dockerfile .
 
       # Push the Docker image to ACR
       - name: Push Docker Image
         run: | 
-          docker push crkloudidentity.azurecr.io/scimconnector-api:${{ env.version }}
+          docker push acrkidemo-gfazgkhnhdfeamft.azurecr.io/scimconnector-api:${{ env.version }}


### PR DESCRIPTION
This pull request updates the Azure Container Registry (ACR) references in the deployment workflow to point to a new registry. All Docker login, build, and push steps now use the new ACR endpoint.

Deployment pipeline updates:

* Changed the Docker login step to use `acrkidemo-gfazgkhnhdfeamft.azurecr.io` instead of `crkloudidentity.azurecr.io` in `.github/workflows/deploy.yml`.
* Updated the Docker build and push steps to tag and push images to `acrkidemo-gfazgkhnhdfeamft.azurecr.io` instead of the previous registry in `.github/workflows/deploy.yml`.