### PR TITLE
Conditional Hangfire Setup and Code Style Improvements in Startup

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Startup.cs
+++ b/Microsoft.SCIM.WebHostSample/Startup.cs
@@ -71,7 +71,8 @@ namespace Microsoft.SCIM.WebHostSample
         {
             services.AddDbContext<Context>();
 
-            void ConfigureMvcNewtonsoftJsonOptions(MvcNewtonsoftJsonOptions options) => options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+            void ConfigureMvcNewtonsoftJsonOptions(MvcNewtonsoftJsonOptions options) =>
+                options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
 
             void ConfigureAuthenticationOptions(AuthenticationOptions options)
             {
@@ -86,16 +87,17 @@ namespace Microsoft.SCIM.WebHostSample
                 if (this.environment.IsDevelopment())
                 {
                     options.TokenValidationParameters =
-                       new TokenValidationParameters
-                       {
-                           ValidateIssuer = false,
-                           ValidateAudience = false,
-                           ValidateLifetime = false,
-                           ValidateIssuerSigningKey = false,
-                           ValidIssuer = section["Token:TokenIssuer"],
-                           ValidAudience = section["Token:TokenAudience"],
-                           IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(section["Token:IssuerSigningKey"]))
-                       };
+                        new TokenValidationParameters
+                        {
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidateIssuerSigningKey = false,
+                            ValidIssuer = section["Token:TokenIssuer"],
+                            ValidAudience = section["Token:TokenAudience"],
+                            IssuerSigningKey =
+                                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(section["Token:IssuerSigningKey"]))
+                        };
                 }
                 else
                 {
@@ -103,27 +105,26 @@ namespace Microsoft.SCIM.WebHostSample
                     options.Audience = section["Token:TokenAudience"];
 
                     options.TokenValidationParameters =
-                       new TokenValidationParameters
-                       {
-                           ValidateIssuer = true,
-                           ValidateAudience = true,
-                           ValidateLifetime = false,
-                           ValidateIssuerSigningKey = true,
-                           ValidIssuer = section["Token:TokenIssuer"],
-                           ValidAudience = section["Token:TokenAudience"],
-                           IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(section["Token:IssuerSigningKey"]))
-                       };
+                        new TokenValidationParameters
+                        {
+                            ValidateIssuer = true,
+                            ValidateAudience = true,
+                            ValidateLifetime = false,
+                            ValidateIssuerSigningKey = true,
+                            ValidIssuer = section["Token:TokenIssuer"],
+                            ValidAudience = section["Token:TokenAudience"],
+                            IssuerSigningKey =
+                                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(section["Token:IssuerSigningKey"]))
+                        };
 
                     options.Events = new JwtBearerEvents
                     {
-                        OnTokenValidated = context =>
-                        {
-                            return Task.CompletedTask;
-                        },
+                        OnTokenValidated = context => { return Task.CompletedTask; },
                         OnAuthenticationFailed = AuthenticationFailed
                     };
                 }
             }
+
             services.AddOptions<AppSettings>().Bind(configuration.GetSection("KI"));
 
             services.AddApplicationInsightsTelemetry();
@@ -164,10 +165,7 @@ namespace Microsoft.SCIM.WebHostSample
                         h.Username(options.RabbitMQ.UserName);
                         h.Password(options.RabbitMQ.Password);
                     });
-                    cfg.ReceiveEndpoint("scimservice_in", e =>
-                    {
-                        e.ConfigureConsumer<InterserviceConsumer>(context);
-                    });
+                    cfg.ReceiveEndpoint("scimservice_in", e => { e.ConfigureConsumer<InterserviceConsumer>(context); });
 
                     cfg.ConfigureEndpoints(context);
                 });
@@ -179,13 +177,17 @@ namespace Microsoft.SCIM.WebHostSample
                 var endpointProvider = scope.ServiceProvider.GetService<ISendEndpointProvider>();
 
                 return new KloudIdentityLogger(
-                endpointProvider!,
-                LogSeverities.Information);
+                    endpointProvider!,
+                    LogSeverities.Information);
             });
 
-            services.AddHangfire(x => x.UseSqlServerStorage(configuration["ConnectionStrings:HangfireDBConnection"]));
+            if (configuration["ConnectionStrings:HangfireDBConnection"] != null)
+            {
+                services.AddHangfire(x =>
+                    x.UseSqlServerStorage(configuration["ConnectionStrings:HangfireDBConnection"]));
+                services.AddHangfireServer();
+            }
 
-            services.AddHangfireServer();
             services.AddHealthChecks();
 
             services.AddScoped<NonSCIMGroupProvider>();
@@ -218,16 +220,19 @@ namespace Microsoft.SCIM.WebHostSample
             app.UseHttpsRedirection();
             app.UseAuthentication();
             app.UseAuthorization();
-            app.UseHangfireDashboard("/hangfire/jobs");
+            if (configuration["ConnectionStrings:HangfireDBConnection"] != null)
+            {
+                app.UseHangfireDashboard("/hangfire/jobs");
+            }
+
             app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
             app.UseMiddleware<LicenseValidationMiddleware>();
 
-            app.UseEndpoints(
-                (IEndpointRouteBuilder endpoints) =>
-                {
-                    endpoints.MapDefaultControllerRoute();
-                    endpoints.MapHealthChecks("/api/healthz");
-                });
+            app.UseEndpoints((IEndpointRouteBuilder endpoints) =>
+            {
+                endpoints.MapDefaultControllerRoute();
+                endpoints.MapHealthChecks("/api/healthz");
+            });
         }
 
         private Task AuthenticationFailed(AuthenticationFailedContext arg)


### PR DESCRIPTION
This pull request mainly improves code readability and robustness in the `Startup.cs` file by reformatting code for consistency and making the Hangfire integration conditional on configuration. The changes help ensure that optional features like Hangfire are only enabled when properly configured, and the code style is more uniform throughout the setup.

**Hangfire integration improvements:**

* Hangfire services (`AddHangfire` and `AddHangfireServer`) are now only added if the `HangfireDBConnection` connection string is present in configuration, preventing errors when the connection string is missing.
* The Hangfire dashboard middleware (`UseHangfireDashboard`) is now conditionally registered based on the presence of the `HangfireDBConnection` connection string, ensuring the dashboard is only available when Hangfire is configured.

**Code style and readability:**

* Reformatted several lambda expressions and object initializations (e.g., `ConfigureMvcNewtonsoftJsonOptions`, `ConfigureJwtBearerOptons`, and MassTransit `ReceiveEndpoint`) to use consistent inline or multiline styles, improving code clarity. [[1]](diffhunk://#diff-0546088e6af795826c1a116e82707261d2e8cd7007791bd0979678732a52a98fL74-R75) [[2]](diffhunk://#diff-0546088e6af795826c1a116e82707261d2e8cd7007791bd0979678732a52a98fL97-R99) [[3]](diffhunk://#diff-0546088e6af795826c1a116e82707261d2e8cd7007791bd0979678732a52a98fL114-R127) [[4]](diffhunk://#diff-0546088e6af795826c1a116e82707261d2e8cd7007791bd0979678732a52a98fL167-R168)
* Simplified the `OnTokenValidated` event handler to a single-line lambda for brevity and readability.