### PR TITLE
hotfix(Identifier Retrieval): GetAsync issue fixed

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/RESTIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/RESTIntegration.cs
@@ -252,7 +252,7 @@ public class RESTIntegration : IIntegrationBase
             }
             else
             {
-                core2EntUsr.UserName = GetValueCaseInsensitive(user, usernameField);
+                core2EntUsr.UserName = usernameField == null ? string.Empty : GetValueCaseInsensitive(user, usernameField);
             }
 
             // Create log for the operation.


### PR DESCRIPTION
This pull request makes a minor improvement to the `GetAsync` method in `RESTIntegration.cs`. It ensures that if `usernameField` is null, the `UserName` property is set to an empty string instead of passing a null value to `GetValueCaseInsensitive`.