### PR TITLE
hotfix(Identifier retrieval): Minor bug fixed.

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/RESTIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/RESTIntegration.cs
@@ -298,7 +298,10 @@ public class RESTIntegration : IIntegrationBase
         var property = jsonObject?.Properties()
             .FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
 
-        return property!.Value.ToString();
+        if (property == null)
+            return string.Empty;
+
+        return property.Value.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request makes a small but important improvement to the `GetValueCaseInsensitive` method in `RESTIntegration.cs`. The method now safely handles cases where the requested property does not exist in the JSON object by returning an empty string instead of throwing a `NullReferenceException`. 

* Improved null safety in `GetValueCaseInsensitive` by returning an empty string when the property is not found, preventing potential runtime errors.