### PR TITLE
Bug fix : Verify Mapping - Improve action step and attribute retrieval logic

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/GetVerifiedAttributeMapping.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/GetVerifiedAttributeMapping.cs
@@ -29,12 +29,23 @@ public class GetVerifiedAttributeMapping : IGetVerifiedAttributeMapping
                 $"Application configuration not found for the provided App ID: {appId}. Ensure the App ID is correct and properly configured.");
             throw new NotFoundException(
                 $"Application configuration for App ID '{appId}' was not found. Please verify the App ID and try again.");
-        }       
+        }
+
+        // Find the step by stepId from all actions
+        var step = appConfig.Actions?
+            .SelectMany(a => a.ActionSteps ?? Enumerable.Empty<ActionStep>())
+            .FirstOrDefault(s => s.Id == stepId);
+
+        if (step == null)
+        {
+            Log.Error("Action step not found for App ID: {AppId} and Step ID: {StepId}", appId, stepId);
+            throw new NotFoundException($"Action step not found for App ID: {appId} and Step ID: {stepId}");
+        }
+
 
         if (type == ObjectTypes.Group)
         {
-            var groupAttributes = appConfig.GroupAttributeSchemas?.Where(x => x.ActionStepId == stepId)
-                .ToList();
+            var groupAttributes = step.GroupAttributeSchema?.ToList();
 
             if (groupAttributes == null)
             {
@@ -46,8 +57,7 @@ public class GetVerifiedAttributeMapping : IGetVerifiedAttributeMapping
         }
         else if (type == ObjectTypes.User)
         {
-            var userAttributes = appConfig.UserAttributeSchemas.Where(x => x.ActionStepId == stepId)
-                .ToList();
+            var userAttributes = step.UserAttributeSchemas?.ToList();
 
             if (userAttributes == null)
             {


### PR DESCRIPTION
This pull request refactors how attribute schemas are retrieved for a given action step in the `GetVerifiedAsync` method. Instead of filtering attribute schemas from the entire application configuration, the code now locates the specific action step first and then accesses its associated attribute schemas directly. This change improves clarity and ensures more accurate lookups.

**Improvements to attribute schema retrieval:**

* Added logic to find the relevant `ActionStep` by `stepId` from all actions in the application configuration, throwing a `NotFoundException` if not found.
* Updated retrieval of group and user attribute schemas to access them directly from the located `ActionStep` instead of filtering from the broader application configuration. [[1]](diffhunk://#diff-a2759b3e07c3f165c1ead3626f0bdf0ba278b3b0ca26d7daa4da10bd9a0980aaR34-R48) [[2]](diffhunk://#diff-a2759b3e07c3f165c1ead3626f0bdf0ba278b3b0ca26d7daa4da10bd9a0980aaL49-R60)