### PR TITLE
feat(SOAP Integration): Add SOAP authentication support

### DIFF
--- a/.github/prompts/plan-soapAuthenticationArchitectureFit.prompt.md
+++ b/.github/prompts/plan-soapAuthenticationArchitectureFit.prompt.md
@@ -1,0 +1,175 @@
+## Agent Execution Prompt: SOAP Authentication Build Plan
+
+Implement SOAP authentication support in incremental phases with strict scope control and test-first validation.
+
+### Objective
+
+Add three SOAP-compatible auth modes without breaking existing REST, SQL, or current SOAP behavior.
+
+1. Basic and NTLM transport auth.
+2. WS-Security header injection (`UsernameToken` plain text in phase 1).
+3. Token-based auth in HTTP Authorization header, custom HTTP headers, and custom SOAP header.
+
+### Hard Constraints
+
+1. Preserve backward compatibility of existing `AuthenticationDetails` payloads.
+2. Do not refactor unrelated modules.
+3. Keep existing public contracts stable unless strictly required.
+4. Do not remove current auth methods.
+5. Stop after each phase and report changed files and rationale.
+
+### Scope Decisions (Locked)
+
+1. WS-Security first profile: `UsernameToken` plain text with optional timestamp toggle.
+2. NTLM supports both explicit credentials and default machine credentials via config flag.
+3. Token placement supports all three locations in phase 1:
+
+- HTTP Authorization header
+- Custom HTTP headers
+- Custom SOAP header
+
+### Primary Files
+
+1. `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs`
+2. `KN.KloudIdentity.Mapper/Utils/HttpClientExtensions.cs`
+3. `KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs`
+4. `KN.KloudIdentity.Mapper/Auth/AuthContextV1.cs`
+5. `KN.KloudIdentity.Mapper/Auth/IAuthContext.cs`
+6. `KN.KloudIdentity.Mapper/Auth/IAuthStrategy.cs`
+7. `KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs`
+8. `KN.KloudIdentity.Mapper.Domain/Authentication/AuthenticationMethods.cs`
+9. `KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs`
+
+### Phase Plan
+
+#### Phase 1: Foundation and Contracts
+
+Implement only foundational seams and config contracts.
+
+Tasks:
+
+1. Add SOAP-specific auth application seam (for example `ISoapAuthApplier`) that can:
+
+- modify `HttpRequestMessage` headers
+- modify SOAP XML envelope/header
+- support transport credential decisions for HTTP handlers
+
+2. Add typed SOAP auth option models with backward-compatible deserialization fallback from `AuthenticationDetails`.
+3. Keep `IAuthStrategy` focused on token or key retrieval; do not force WS-Security logic into token strategies.
+
+Done Criteria:
+
+1. Build passes.
+2. No behavior change for existing REST, SQL, and current SOAP auth flows.
+3. Unit tests added for config parsing and seam selection.
+
+Stop and report after Phase 1.
+
+#### Phase 2: Implement Auth Modes
+
+Implement concrete auth behavior.
+
+Tasks:
+
+1. Basic and NTLM transport auth:
+
+- Basic path uses existing header logic.
+- NTLM path configures credentials (`HttpClientHandler.Credentials`) and supports explicit or default credentials.
+
+2. WS-Security injection:
+
+- create `<soap:Header>` if absent
+- inject `<wsse:Security>` and required namespaces
+- inject UsernameToken plain text
+- optional timestamp based on config
+
+3. Token placement:
+
+- Authorization header
+- custom HTTP headers
+- custom SOAP header fragment with token placeholder substitution
+
+4. Define deterministic precedence when multiple placements are enabled.
+
+Done Criteria:
+
+1. New tests validate each auth mode independently.
+2. Mixed-mode test validates combined token placements.
+3. SOAP body mapping remains unchanged except intended header injection.
+
+Stop and report after Phase 2.
+
+#### Phase 3: Wire SOAP Integration and DI
+
+Integrate the new auth pipeline and ensure runtime resolution.
+
+Tasks:
+
+1. Refactor `SOAPIntegration` request flow to use `HttpRequestMessage` and SOAP auth appliers.
+2. Remove hardcoded bearer assignment.
+3. Reuse shared custom header handling where applicable.
+4. Register missing DI services:
+
+- `BearerAuthStratergy`
+- `SOAPIntegration`
+- SOAP auth appliers
+
+5. Verify `IntegrationBaseFactory` still resolves mapped integration correctly.
+
+Done Criteria:
+
+1. SOAP integration tests pass with new auth paths.
+2. Existing SOAP tests remain green.
+3. DI composition verifies all required auth services are registered.
+
+Stop and report after Phase 3.
+
+#### Phase 4: Compatibility and Regression Safety
+
+Finalize regression protection and documentation notes.
+
+Tasks:
+
+1. Add/extend tests for:
+
+- NTLM explicit vs default credential selection
+- WS-Security XML structure
+- token placement locations
+- integration factory resolution
+
+2. Validate no regressions in REST and SQL auth flows.
+3. Add concise migration notes for optional new SOAP auth fields.
+
+Done Criteria:
+
+1. Targeted test suites pass.
+2. No changed behavior for legacy configs.
+3. Summary includes remaining known risks.
+
+### Non-Goals (Phase 1 Rollout)
+
+1. WS-Security digest or X.509 signature/canonicalization.
+2. Large auth framework redesign.
+3. Global enum cleanup beyond what is necessary for SOAP implementation.
+
+### Mandatory Validation Commands
+
+Run and report results for relevant tests before each phase handoff.
+
+1. `dotnet test KN.KloudIdentity.MapperTests/KN.KloudIdentity.MapperTests.csproj --filter SOAPIntegration`
+2. If no filterable tests exist, run: `dotnet test KN.KloudIdentity.MapperTests/KN.KloudIdentity.MapperTests.csproj`
+
+### Output Format For Each Phase Handoff
+
+Return exactly these sections:
+
+1. `Phase Completed`
+2. `Files Changed`
+3. `Behavior Added`
+4. `Tests Executed`
+5. `Compatibility Check`
+6. `Risks/Follow-ups`
+
+### Execution Start Instruction
+
+Start with Phase 1 only. Do not begin Phase 2 until Phase 1 handoff is produced.

--- a/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
@@ -23,4 +23,5 @@ public record AppConfig
     public ExternalEndpointInfo? ExternalEndpointInfo { get; set; }
     public dynamic? IntegrationDetails { get; set; }
     public ICollection<SOAPTemplate>? SOAPTemplates { get; set; }
+    public SOAPAuthenticationOptions? SOAPAuthenticationOptions { get; set; }
 }

--- a/KN.KloudIdentity.Mapper.Domain/Application/SOAPAuthenticationOptions.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/SOAPAuthenticationOptions.cs
@@ -1,0 +1,35 @@
+namespace KN.KloudIdentity.Mapper.Domain.Application;
+
+public record SOAPAuthenticationOptions
+{
+    public BasicOrNtlmSoapAuthOptions? Transport { get; init; }
+    public WsSecuritySoapAuthOptions? WsSecurity { get; init; }
+    public SoapTokenPlacementOptions? TokenPlacement { get; init; }
+}
+
+public record BasicOrNtlmSoapAuthOptions
+{
+    public bool Enabled { get; init; }
+    public bool UseNtlm { get; init; }
+    public bool UseDefaultCredentials { get; init; }
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+    public string? Domain { get; init; }
+}
+
+public record WsSecuritySoapAuthOptions
+{
+    public bool Enabled { get; init; }
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+    public bool IncludeTimestamp { get; init; }
+}
+
+public record SoapTokenPlacementOptions
+{
+    public bool Enabled { get; init; }
+    public bool UseAuthorizationHeader { get; init; }
+    public Dictionary<string, string>? CustomHttpHeaders { get; init; }
+    public string? SoapHeaderTemplate { get; init; }
+    public string TokenPlaceholder { get; init; } = "{{token}}";
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/ISoapAuthApplier.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/ISoapAuthApplier.cs
@@ -1,0 +1,21 @@
+using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Mapping;
+
+namespace KN.KloudIdentity.Mapper.MapperCore;
+
+public interface ISoapAuthApplier
+{
+    Task ApplyAsync(SoapAuthContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed class SoapAuthContext
+{
+    public required AppConfig AppConfig { get; init; }
+    public required SCIMDirections Direction { get; init; }
+    public required HttpClient HttpClient { get; init; }
+    public required HttpRequestMessage Request { get; init; }
+    public HttpClientHandler? Handler { get; init; }
+    public string? Token { get; init; }
+    public SOAPAuthenticationOptions? AuthOptions { get; init; }
+    public required string Payload { get; set; }
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/SoapTokenHeaderApplier.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/SoapTokenHeaderApplier.cs
@@ -1,0 +1,59 @@
+using System.Xml;
+
+namespace KN.KloudIdentity.Mapper.MapperCore;
+
+public sealed class SoapTokenHeaderApplier : ISoapAuthApplier
+{
+    private const string Soap11Ns = "http://schemas.xmlsoap.org/soap/envelope/";
+
+    public Task ApplyAsync(SoapAuthContext context, CancellationToken cancellationToken = default)
+    {
+        var placement = context.AuthOptions?.TokenPlacement;
+        if (placement?.Enabled != true || string.IsNullOrWhiteSpace(placement.SoapHeaderTemplate))
+        {
+            return Task.CompletedTask;
+        }
+
+        var tokenValue = context.Token ?? string.Empty;
+        var tokenPlaceholder = placement.TokenPlaceholder;
+        var headerFragment = placement.SoapHeaderTemplate.Replace(tokenPlaceholder, tokenValue, StringComparison.Ordinal);
+
+        var document = new XmlDocument { XmlResolver = null };
+        document.LoadXml(context.Payload);
+
+        var envelope = document.DocumentElement;
+        if (envelope == null || !envelope.LocalName.Equals("Envelope", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("SOAP Envelope is required for custom SOAP header injection.");
+        }
+
+        var soapNs = string.IsNullOrWhiteSpace(envelope.NamespaceURI) ? Soap11Ns : envelope.NamespaceURI;
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("soap", soapNs);
+
+        var header = document.SelectSingleNode("/soap:Envelope/soap:Header", nsmgr) as XmlElement;
+        if (header == null)
+        {
+            header = document.CreateElement("soap", "Header", soapNs);
+            var body = document.SelectSingleNode("/soap:Envelope/soap:Body", nsmgr);
+            if (body?.ParentNode == null)
+            {
+                throw new InvalidOperationException("SOAP Body is required for custom SOAP header injection.");
+            }
+
+            body.ParentNode.InsertBefore(header, body);
+        }
+
+        var fragmentDocument = new XmlDocument { XmlResolver = null };
+        fragmentDocument.LoadXml($"<root>{headerFragment}</root>");
+
+        foreach (XmlNode child in fragmentDocument.DocumentElement!.ChildNodes)
+        {
+            var importedNode = document.ImportNode(child, true);
+            header.AppendChild(importedNode);
+        }
+
+        context.Payload = document.OuterXml;
+        return Task.CompletedTask;
+    }
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/SoapTransportAuthApplier.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/SoapTransportAuthApplier.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Net.Http.Headers;
+using KN.KloudIdentity.Mapper.Domain.Application;
+
+namespace KN.KloudIdentity.Mapper.MapperCore;
+
+public sealed class SoapTransportAuthApplier : ISoapAuthApplier
+{
+    public Task ApplyAsync(SoapAuthContext context, CancellationToken cancellationToken = default)
+    {
+        var transport = context.AuthOptions?.Transport;
+        if (transport?.Enabled == true && transport.UseNtlm)
+        {
+            if (context.Handler == null)
+            {
+                throw new InvalidOperationException("SOAP NTLM authentication requires an HttpClientHandler.");
+            }
+
+            if (transport.UseDefaultCredentials)
+            {
+                context.Handler.UseDefaultCredentials = true;
+                context.Handler.Credentials = CredentialCache.DefaultNetworkCredentials;
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(transport.Username) || string.IsNullOrWhiteSpace(transport.Password))
+                {
+                    throw new InvalidOperationException("SOAP NTLM authentication requires username and password when UseDefaultCredentials is false.");
+                }
+
+                context.Handler.Credentials = new NetworkCredential(transport.Username, transport.Password, transport.Domain);
+            }
+        }
+
+        var tokenPlacement = context.AuthOptions?.TokenPlacement;
+        if (tokenPlacement?.Enabled == true)
+        {
+            if (tokenPlacement.UseAuthorizationHeader && !string.IsNullOrWhiteSpace(context.Token))
+            {
+                context.Request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.Token);
+            }
+
+            if (tokenPlacement.CustomHttpHeaders != null)
+            {
+                foreach (var header in tokenPlacement.CustomHttpHeaders)
+                {
+                    var value = header.Value;
+                    if (!string.IsNullOrWhiteSpace(context.Token))
+                    {
+                        value = value.Replace(tokenPlacement.TokenPlaceholder, context.Token, StringComparison.Ordinal);
+                    }
+
+                    context.Request.Headers.TryAddWithoutValidation(header.Key, value);
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/WsSecuritySoapAuthApplier.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/WsSecuritySoapAuthApplier.cs
@@ -33,6 +33,7 @@ public sealed class WsSecuritySoapAuthApplier : ISoapAuthApplier
         var soapNs = string.IsNullOrWhiteSpace(envelope.NamespaceURI) ? Soap11Ns : envelope.NamespaceURI;
         var nsmgr = new XmlNamespaceManager(document.NameTable);
         nsmgr.AddNamespace("soap", soapNs);
+        nsmgr.AddNamespace("wsse", WsseNs);
 
         var header = document.SelectSingleNode("/soap:Envelope/soap:Header", nsmgr) as XmlElement;
         if (header == null)
@@ -47,7 +48,13 @@ public sealed class WsSecuritySoapAuthApplier : ISoapAuthApplier
             body.ParentNode.InsertBefore(header, body);
         }
 
-        var security = document.CreateElement("wsse", "Security", WsseNs);
+        var security = header.SelectSingleNode("wsse:Security", nsmgr) as XmlElement;
+        if (security == null)
+        {
+            security = document.CreateElement("wsse", "Security", WsseNs);
+            header.AppendChild(security);
+        }
+
         var usernameToken = document.CreateElement("wsse", "UsernameToken", WsseNs);
 
         var username = document.CreateElement("wsse", "Username", WsseNs);
@@ -74,7 +81,6 @@ public sealed class WsSecuritySoapAuthApplier : ISoapAuthApplier
         }
 
         security.AppendChild(usernameToken);
-        header.AppendChild(security);
 
         context.Payload = document.OuterXml;
         return Task.CompletedTask;

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/WsSecuritySoapAuthApplier.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/WsSecuritySoapAuthApplier.cs
@@ -1,0 +1,82 @@
+using System.Xml;
+
+namespace KN.KloudIdentity.Mapper.MapperCore;
+
+public sealed class WsSecuritySoapAuthApplier : ISoapAuthApplier
+{
+    private const string Soap11Ns = "http://schemas.xmlsoap.org/soap/envelope/";
+    private const string WsseNs = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+    private const string WsuNs = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+
+    public Task ApplyAsync(SoapAuthContext context, CancellationToken cancellationToken = default)
+    {
+        var wsSecurity = context.AuthOptions?.WsSecurity;
+        if (wsSecurity?.Enabled != true)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (string.IsNullOrWhiteSpace(wsSecurity.Username) || string.IsNullOrWhiteSpace(wsSecurity.Password))
+        {
+            throw new InvalidOperationException("WS-Security UsernameToken requires both username and password.");
+        }
+
+        var document = new XmlDocument { XmlResolver = null };
+        document.LoadXml(context.Payload);
+
+        var envelope = document.DocumentElement;
+        if (envelope == null || !envelope.LocalName.Equals("Envelope", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("SOAP Envelope is required for WS-Security injection.");
+        }
+
+        var soapNs = string.IsNullOrWhiteSpace(envelope.NamespaceURI) ? Soap11Ns : envelope.NamespaceURI;
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("soap", soapNs);
+
+        var header = document.SelectSingleNode("/soap:Envelope/soap:Header", nsmgr) as XmlElement;
+        if (header == null)
+        {
+            header = document.CreateElement("soap", "Header", soapNs);
+            var body = document.SelectSingleNode("/soap:Envelope/soap:Body", nsmgr);
+            if (body?.ParentNode == null)
+            {
+                throw new InvalidOperationException("SOAP Body is required for WS-Security injection.");
+            }
+
+            body.ParentNode.InsertBefore(header, body);
+        }
+
+        var security = document.CreateElement("wsse", "Security", WsseNs);
+        var usernameToken = document.CreateElement("wsse", "UsernameToken", WsseNs);
+
+        var username = document.CreateElement("wsse", "Username", WsseNs);
+        username.InnerText = wsSecurity.Username;
+        usernameToken.AppendChild(username);
+
+        var password = document.CreateElement("wsse", "Password", WsseNs);
+        password.InnerText = wsSecurity.Password;
+        usernameToken.AppendChild(password);
+
+        if (wsSecurity.IncludeTimestamp)
+        {
+            var timestamp = document.CreateElement("wsu", "Timestamp", WsuNs);
+            var created = document.CreateElement("wsu", "Created", WsuNs);
+            var expires = document.CreateElement("wsu", "Expires", WsuNs);
+            var utcNow = DateTime.UtcNow;
+
+            created.InnerText = utcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+            expires.InnerText = utcNow.AddMinutes(5).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+            timestamp.AppendChild(created);
+            timestamp.AppendChild(expires);
+            security.AppendChild(timestamp);
+        }
+
+        security.AppendChild(usernameToken);
+        header.AppendChild(security);
+
+        context.Payload = document.OuterXml;
+        return Task.CompletedTask;
+    }
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using KN.KI.LogAggregator.Library.Abstractions;
 using KN.KloudIdentity.Mapper.Domain;
 using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Authentication;
 using KN.KloudIdentity.Mapper.Domain.Mapping;
 using KN.KloudIdentity.Mapper.MapperCore;
 using KN.KloudIdentity.Mapper.Utils;
@@ -29,6 +31,7 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         private readonly IConfiguration _configuration;
         private readonly IKloudIdentityLogger _logger;
         private readonly AppSettings _appSettings;
+        private readonly IReadOnlyList<ISoapAuthApplier> _soapAuthAppliers;
         public IntegrationMethods IntegrationMethod { get; init; }
 
         public SOAPIntegration(
@@ -36,7 +39,8 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             IHttpClientFactory httpClientFactory,
             IConfiguration configuration,
             IOptions<AppSettings> appSettings,
-            IKloudIdentityLogger logger)
+            IKloudIdentityLogger logger,
+            IEnumerable<ISoapAuthApplier>? soapAuthAppliers = null)
         {
             IntegrationMethod = IntegrationMethods.SOAP;
             _authContext = authContext;
@@ -44,6 +48,12 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             _configuration = configuration;
             _logger = logger;
             _appSettings = appSettings.Value;
+            _soapAuthAppliers = [.. (soapAuthAppliers ??
+            [
+                new SoapTransportAuthApplier(),
+                new WsSecuritySoapAuthApplier(),
+                new SoapTokenHeaderApplier()
+            ])];
         }
 
         public virtual async Task<dynamic> GetAuthenticationAsync(AppConfig config, SCIMDirections direction = SCIMDirections.Outbound, CancellationToken cancellationToken = default, params dynamic[] args)
@@ -174,9 +184,29 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         /// <returns>Response body as string.</returns>
         private async Task<string> SendSoapRequestAsync(Uri uri, string payload, AppConfig appConfig, SCIMDirections direction, string correlationId, CancellationToken cancellationToken = default)
         {
-            var httpClient = await CreateHttpClientAsync(appConfig, direction, cancellationToken);
-            var content = new StringContent(payload, Encoding.UTF8, "text/xml");
-            var response = await httpClient.PostAsync(uri, content, cancellationToken);
+            var soapAuthOptions = ResolveSoapAuthenticationOptions(appConfig);
+            var (httpClient, handler, token) = await CreateHttpClientAsync(appConfig, direction, soapAuthOptions, cancellationToken);
+
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            var authContext = new SoapAuthContext
+            {
+                AppConfig = appConfig,
+                Direction = direction,
+                HttpClient = httpClient,
+                Request = request,
+                Handler = handler,
+                Token = token,
+                AuthOptions = soapAuthOptions,
+                Payload = payload
+            };
+
+            foreach (var applier in _soapAuthAppliers)
+            {
+                await applier.ApplyAsync(authContext, cancellationToken);
+            }
+
+            request.Content = new StringContent(authContext.Payload, Encoding.UTF8, "text/xml");
+            var response = await httpClient.SendAsync(request, cancellationToken);
             string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
             // Check for HTTP error
@@ -196,19 +226,130 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             return responseBody;
         }
 
-        private async Task<HttpClient> CreateHttpClientAsync(AppConfig appConfig, SCIMDirections direction, CancellationToken cancellationToken = default)
+        private async Task<(HttpClient client, HttpClientHandler? handler, string? token)> CreateHttpClientAsync(AppConfig appConfig, SCIMDirections direction, SOAPAuthenticationOptions? soapAuthOptions, CancellationToken cancellationToken = default)
         {
-            var client = _httpClientFactory.CreateClient();
-            // Set headers, authentication, etc. as needed
-            // Example: client.DefaultRequestHeaders.Add("SOAPAction", ...);
-            // Add token if required
-            var token = await GetAuthenticationAsync(appConfig, direction, cancellationToken);
-            if (token is string t && !string.IsNullOrEmpty(t))
+            var isNtlmEnabled = soapAuthOptions?.Transport?.Enabled == true && soapAuthOptions.Transport.UseNtlm;
+            HttpClientHandler? handler = null;
+            var client = isNtlmEnabled
+                ? CreateHttpClientForNtlm(out handler)
+                : _httpClientFactory.CreateClient();
+
+            string? token = null;
+            if (ShouldResolveToken(appConfig, soapAuthOptions, direction))
             {
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", t);
+                token = await GetAuthenticationAsync(appConfig, direction, cancellationToken);
             }
 
-            return client;
+            if (!isNtlmEnabled && !string.IsNullOrWhiteSpace(token) && appConfig.AuthenticationMethodOutbound != AuthenticationMethods.None)
+            {
+                Utils.HttpClientExtensions.SetAuthenticationHeaders(
+                   client,
+                   appConfig.AuthenticationMethodOutbound,
+                   NormalizeAuthenticationDetails(appConfig.AuthenticationDetails),
+                   token);
+            }
+
+            var customHttpClient = _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == appConfig.AppId);
+            if (customHttpClient?.HttpSettings?.Headers is { Count: > 0 })
+            {
+                client.SetCustomHeaders(customHttpClient.HttpSettings.Headers);
+            }
+
+            return (client, handler, token);
+        }
+
+        protected virtual HttpClient CreateHttpClientForNtlm(out HttpClientHandler handler)
+        {
+            handler = new HttpClientHandler();
+            return new HttpClient(handler);
+        }
+
+        private static bool ShouldResolveToken(AppConfig appConfig, SOAPAuthenticationOptions? options, SCIMDirections direction)
+        {
+            var authMethod = direction == SCIMDirections.Inbound
+                ? appConfig.AuthenticationMethodInbound
+                : appConfig.AuthenticationMethodOutbound;
+
+            if (authMethod != AuthenticationMethods.None)
+            {
+                return true;
+            }
+
+            var tokenPlacement = options?.TokenPlacement;
+            if (tokenPlacement?.Enabled != true)
+            {
+                return false;
+            }
+
+            return tokenPlacement.UseAuthorizationHeader
+                || (tokenPlacement.CustomHttpHeaders != null && tokenPlacement.CustomHttpHeaders.Count > 0)
+                || !string.IsNullOrWhiteSpace(tokenPlacement.SoapHeaderTemplate);
+        }
+
+        private static SOAPAuthenticationOptions? ResolveSoapAuthenticationOptions(AppConfig appConfig)
+        {
+            if (appConfig.SOAPAuthenticationOptions != null)
+            {
+                return appConfig.SOAPAuthenticationOptions;
+            }
+
+            if (appConfig.AuthenticationDetails == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var authDetailsJson = JsonSerializer.Serialize(appConfig.AuthenticationDetails);
+                using var document = JsonDocument.Parse(authDetailsJson);
+                var root = document.RootElement;
+                SOAPAuthenticationOptions? options;
+
+                if (TryReadSoapAuthOptions(root, "SOAPAuthenticationOptions", out options)
+                    || TryReadSoapAuthOptions(root, "SoapAuthenticationOptions", out options)
+                    || TryReadSoapAuthOptions(root, "soapAuthenticationOptions", out options)
+                    || TryReadSoapAuthOptions(root, "soapAuthOptions", out options))
+                {
+                    return options;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+            return null;
+        }
+
+        private static bool TryReadSoapAuthOptions(JsonElement root, string propertyName, out SOAPAuthenticationOptions? options)
+        {
+            options = null;
+            if (!root.TryGetProperty(propertyName, out var value))
+            {
+                return false;
+            }
+
+            options = value.Deserialize<SOAPAuthenticationOptions>(new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            return options != null;
+        }
+
+        private static dynamic NormalizeAuthenticationDetails(dynamic authenticationDetails)
+        {
+            if (authenticationDetails is null)
+            {
+                return "{}";
+            }
+
+            if (authenticationDetails is string authDetailsString)
+            {
+                return authDetailsString;
+            }
+
+            return JsonSerializer.Serialize(authenticationDetails);
         }
 
         public virtual string ExtractIdentifierFromSoapResponse(string responseBody, AppConfig appConfig)

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -260,8 +260,9 @@ namespace KN.KloudIdentity.Mapper.MapperCore
 
         protected virtual HttpClient CreateHttpClientForNtlm(out HttpClientHandler handler)
         {
-            handler = new HttpClientHandler();
-            return new HttpClient(handler);
+            // Handler is configured by DI for this named client, so no manual `new HttpClient(...)`.
+            handler = null!;
+            return _httpClientFactory.CreateClient(AppConstant.NtlmSoapClientName);
         }
 
         private static bool ShouldResolveToken(AppConfig appConfig, SOAPAuthenticationOptions? options, SCIMDirections direction)
@@ -281,9 +282,20 @@ namespace KN.KloudIdentity.Mapper.MapperCore
                 return false;
             }
 
-            return tokenPlacement.UseAuthorizationHeader
+            var hasEffectiveTokenPlacement =
+                tokenPlacement.UseAuthorizationHeader
                 || (tokenPlacement.CustomHttpHeaders != null && tokenPlacement.CustomHttpHeaders.Count > 0)
                 || !string.IsNullOrWhiteSpace(tokenPlacement.SoapHeaderTemplate);
+
+            if (hasEffectiveTokenPlacement)
+            {
+                throw new InvalidOperationException(
+                    "Token placement is enabled for a SOAP integration, but the authentication method is set to 'None'. " +
+                    "Configure a token-producing authentication method for the specified direction (inbound or outbound) " +
+                    "when using token placement.");
+            }
+
+            return false;
         }
 
         private static SOAPAuthenticationOptions? ResolveSoapAuthenticationOptions(AppConfig appConfig)
@@ -313,8 +325,19 @@ namespace KN.KloudIdentity.Mapper.MapperCore
                     return options;
                 }
             }
+            catch (JsonException ex)
+            {
+                Log.Error(ex, "Failed to parse SOAP authentication options from AuthenticationDetails. AppId: {AppId}", appConfig.AppId);
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                Log.Error(ex, "Failed to parse SOAP authentication options from AuthenticationDetails. AppId: {AppId}", appConfig.AppId);
+                return null;
+            }
             catch
             {
+                Log.Error("Failed to parse SOAP authentication options from AuthenticationDetails due to an unexpected error. AppId: {AppId}", appConfig.AppId);
                 return null;
             }
 

--- a/KN.KloudIdentity.Mapper/Utils/AppConstant.cs
+++ b/KN.KloudIdentity.Mapper/Utils/AppConstant.cs
@@ -2,6 +2,7 @@
 
 public class AppConstant
 {
-    public  const string LoggerName = "KN.KloudIdentity.SCIM";
+    public const string LoggerName = "KN.KloudIdentity.SCIM";
     public const string User = "system";
+    public const string NtlmSoapClientName = "soap-ntlm";
 }

--- a/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
+++ b/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
@@ -38,6 +38,14 @@ public static class ServiceExtension
     public static void ConfigureMapperServices(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddHttpClient();
+        services.AddHttpClient(AppConstant.NtlmSoapClientName)
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                    new HttpClientHandler
+                    {
+                        UseDefaultCredentials = true
+                        // or static credentials if your app uses fixed service credentials
+                    });
+
         services.AddMemoryCache();
         services.AddScoped<Context>();
 

--- a/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
+++ b/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
@@ -45,8 +45,12 @@ public static class ServiceExtension
         services.AddScoped<IAuthContext, AuthContextV1>();
         services.AddScoped<IAuthStrategy, ApiKeyStrategy>();
         services.AddScoped<IAuthStrategy, BasicAuthStrategy>();
+        services.AddScoped<IAuthStrategy, BearerAuthStratergy>();
         services.AddScoped<IAuthStrategy, OAuth2Strategy>();
         services.AddScoped<IAuthStrategy, DotRezAuthStrategy>();
+        services.AddScoped<ISoapAuthApplier, SoapTransportAuthApplier>();
+        services.AddScoped<ISoapAuthApplier, WsSecuritySoapAuthApplier>();
+        services.AddScoped<ISoapAuthApplier, SoapTokenHeaderApplier>();
 
         services.AddScoped<IConfigReader, ConfigReaderSQL>();
 
@@ -54,7 +58,7 @@ public static class ServiceExtension
         {
             return provider.GetServices<IIntegrationBase>().ToList();
         });
-                
+
         var appSettingsSection = configuration.GetSection("KI");
         var appSettings = appSettingsSection.Get<AppSettings>();
         var connectionString = appSettings?.UserMigration?.AzureStorageConnectionString;
@@ -69,14 +73,15 @@ public static class ServiceExtension
         }
 
         services.AddScoped<ICreateResourceV2, CreateUserV3>();
-       
-        services.AddScoped<IIntegrationBase, RestIntegrationManageEngine>(); 
+
+        services.AddScoped<IIntegrationBase, RestIntegrationManageEngine>();
         services.AddScoped<IIntegrationBase, RESTIntegrationV2>();
-        
+
         services.AddScoped<IIntegrationBase, RESTIntegration>();
         services.AddScoped<IIntegrationBase, LinuxIntegration>();
         services.AddScoped<IIntegrationBase, AS400Integration>();
         services.AddScoped<IIntegrationBase, SQLIntegration>();
+        services.AddScoped<IIntegrationBase, SOAPIntegration>();
 
         services.AddScoped<IIntegrationBaseFactory, IntegrationBaseFactory>();
 

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPAuthApplierUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPAuthApplierUnitTests.cs
@@ -159,6 +159,50 @@ public class SOAPAuthApplierUnitTests
     }
 
     [Fact]
+    public async Task WsSecuritySoapAuthApplier_WhenSecurityAlreadyExists_DoesNotCreateDuplicateSecurityNode()
+    {
+        const string payload = """
+                        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+                            <soap:Header>
+                                <wsse:Security>
+                                    <wsse:UsernameToken>
+                                        <wsse:Username>existing-user</wsse:Username>
+                                    </wsse:UsernameToken>
+                                </wsse:Security>
+                            </soap:Header>
+                            <soap:Body>
+                                <CreateUser />
+                            </soap:Body>
+                        </soap:Envelope>
+                        """;
+
+        var context = CreateContext(
+                payload: payload,
+                authOptions: new SOAPAuthenticationOptions
+                {
+                    WsSecurity = new WsSecuritySoapAuthOptions
+                    {
+                        Enabled = true,
+                        Username = "ws-user",
+                        Password = "ws-pass",
+                        IncludeTimestamp = false
+                    }
+                });
+
+        await new WsSecuritySoapAuthApplier().ApplyAsync(context);
+
+        var doc = new XmlDocument();
+        doc.LoadXml(context.Payload);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("soap", "http://schemas.xmlsoap.org/soap/envelope/");
+        ns.AddNamespace("wsse", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+
+        var securityNodes = doc.SelectNodes("/soap:Envelope/soap:Header/wsse:Security", ns);
+        Assert.NotNull(securityNodes);
+        Assert.Equal(1, securityNodes!.Count);
+    }
+
+    [Fact]
     public async Task SoapTokenHeaderApplier_WithSoapHeaderPlacement_AddsConfiguredHeaderFragment()
     {
         var context = CreateContext(

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPAuthApplierUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPAuthApplierUnitTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Net.Http;
+using System.Xml;
+using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Mapping;
+using KN.KloudIdentity.Mapper.MapperCore;
+
+namespace KN.KloudIdentity.MapperTests.SOAPIntegration;
+
+public class SOAPAuthApplierUnitTests
+{
+    [Fact]
+    public async Task SoapTransportAuthApplier_WithNtlmExplicitCredentials_SetsNetworkCredential()
+    {
+        var handler = new HttpClientHandler();
+        var context = CreateContext(
+            handler: handler,
+            authOptions: new SOAPAuthenticationOptions
+            {
+                Transport = new BasicOrNtlmSoapAuthOptions
+                {
+                    Enabled = true,
+                    UseNtlm = true,
+                    UseDefaultCredentials = false,
+                    Username = "ntlm-user",
+                    Password = "ntlm-pass",
+                    Domain = "CORP"
+                }
+            });
+
+        await new SoapTransportAuthApplier().ApplyAsync(context);
+
+        var credential = Assert.IsType<NetworkCredential>(handler.Credentials);
+        Assert.Equal("ntlm-user", credential.UserName);
+        Assert.Equal("ntlm-pass", credential.Password);
+        Assert.Equal("CORP", credential.Domain);
+        Assert.False(handler.UseDefaultCredentials);
+    }
+
+    [Fact]
+    public async Task SoapTransportAuthApplier_WithNtlmDefaultCredentials_UsesDefaultCredentialFlag()
+    {
+        var handler = new HttpClientHandler();
+        var context = CreateContext(
+            handler: handler,
+            authOptions: new SOAPAuthenticationOptions
+            {
+                Transport = new BasicOrNtlmSoapAuthOptions
+                {
+                    Enabled = true,
+                    UseNtlm = true,
+                    UseDefaultCredentials = true
+                }
+            });
+
+        await new SoapTransportAuthApplier().ApplyAsync(context);
+
+        Assert.True(handler.UseDefaultCredentials);
+        Assert.NotNull(handler.Credentials);
+    }
+
+    [Fact]
+    public async Task SoapTransportAuthApplier_WithAuthorizationPlacement_AddsBearerHeader()
+    {
+        var context = CreateContext(
+            token: "token-abc",
+            authOptions: new SOAPAuthenticationOptions
+            {
+                TokenPlacement = new SoapTokenPlacementOptions
+                {
+                    Enabled = true,
+                    UseAuthorizationHeader = true
+                }
+            });
+
+        await new SoapTransportAuthApplier().ApplyAsync(context);
+
+        Assert.NotNull(context.Request.Headers.Authorization);
+        Assert.Equal("Bearer", context.Request.Headers.Authorization!.Scheme);
+        Assert.Equal("token-abc", context.Request.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task SoapTransportAuthApplier_WithCustomHttpPlacement_ReplacesTokenPlaceholder()
+    {
+        var context = CreateContext(
+            token: "token-xyz",
+            authOptions: new SOAPAuthenticationOptions
+            {
+                TokenPlacement = new SoapTokenPlacementOptions
+                {
+                    Enabled = true,
+                    CustomHttpHeaders = new Dictionary<string, string>
+                    {
+                        ["X-Api-Token"] = "Bearer {{token}}"
+                    }
+                }
+            });
+
+        await new SoapTransportAuthApplier().ApplyAsync(context);
+
+        Assert.True(context.Request.Headers.TryGetValues("X-Api-Token", out var values));
+        Assert.Equal("Bearer token-xyz", values.Single());
+    }
+
+    [Fact]
+    public async Task WsSecuritySoapAuthApplier_WithTimestamp_AddsExpectedWsSecurityNodes()
+    {
+        var context = CreateContext(
+            authOptions: new SOAPAuthenticationOptions
+            {
+                WsSecurity = new WsSecuritySoapAuthOptions
+                {
+                    Enabled = true,
+                    Username = "ws-user",
+                    Password = "ws-pass",
+                    IncludeTimestamp = true
+                }
+            });
+
+        await new WsSecuritySoapAuthApplier().ApplyAsync(context);
+
+        var doc = new XmlDocument();
+        doc.LoadXml(context.Payload);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("soap", "http://schemas.xmlsoap.org/soap/envelope/");
+        ns.AddNamespace("wsse", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+        ns.AddNamespace("wsu", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
+
+        Assert.NotNull(doc.SelectSingleNode("/soap:Envelope/soap:Header/wsse:Security", ns));
+        Assert.Equal("ws-user", doc.SelectSingleNode("//wsse:Username", ns)?.InnerText);
+        Assert.Equal("ws-pass", doc.SelectSingleNode("//wsse:Password", ns)?.InnerText);
+        Assert.NotNull(doc.SelectSingleNode("//wsu:Timestamp", ns));
+    }
+
+    [Fact]
+    public async Task WsSecuritySoapAuthApplier_WithoutTimestamp_DoesNotAddTimestampNode()
+    {
+        var context = CreateContext(
+            authOptions: new SOAPAuthenticationOptions
+            {
+                WsSecurity = new WsSecuritySoapAuthOptions
+                {
+                    Enabled = true,
+                    Username = "ws-user",
+                    Password = "ws-pass",
+                    IncludeTimestamp = false
+                }
+            });
+
+        await new WsSecuritySoapAuthApplier().ApplyAsync(context);
+
+        var doc = new XmlDocument();
+        doc.LoadXml(context.Payload);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("wsu", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
+
+        Assert.Null(doc.SelectSingleNode("//wsu:Timestamp", ns));
+    }
+
+    [Fact]
+    public async Task SoapTokenHeaderApplier_WithSoapHeaderPlacement_AddsConfiguredHeaderFragment()
+    {
+        var context = CreateContext(
+            token: "soap-token",
+            authOptions: new SOAPAuthenticationOptions
+            {
+                TokenPlacement = new SoapTokenPlacementOptions
+                {
+                    Enabled = true,
+                    SoapHeaderTemplate = "<auth:Token xmlns:auth='urn:test'>{{token}}</auth:Token>"
+                }
+            });
+
+        await new SoapTokenHeaderApplier().ApplyAsync(context);
+
+        var doc = new XmlDocument();
+        doc.LoadXml(context.Payload);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("soap", "http://schemas.xmlsoap.org/soap/envelope/");
+        ns.AddNamespace("auth", "urn:test");
+
+        Assert.Equal("soap-token", doc.SelectSingleNode("/soap:Envelope/soap:Header/auth:Token", ns)?.InnerText);
+    }
+
+    private static SoapAuthContext CreateContext(
+        HttpClientHandler? handler = null,
+        SOAPAuthenticationOptions? authOptions = null,
+        string? token = null,
+        string? payload = null)
+    {
+        return new SoapAuthContext
+        {
+            AppConfig = new AppConfig
+            {
+                AppId = "soap-app",
+                AuthenticationDetails = new { },
+                UserAttributeSchemas = new List<AttributeSchema>(),
+                UserURIs = new List<UserURIs>()
+            },
+            Direction = SCIMDirections.Outbound,
+            HttpClient = new HttpClient(),
+            Request = new HttpRequestMessage(HttpMethod.Post, "https://soap.example.test/users"),
+            Handler = handler,
+            Token = token,
+            AuthOptions = authOptions,
+            Payload = payload ??
+                "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body><CreateUser /></soap:Body></soap:Envelope>"
+        };
+    }
+}

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
@@ -416,7 +416,7 @@ public class SOAPIntegrationUnitTests
 
         var sut = CreateSut(handler, "token-123");
         var appConfig = CreateAppConfig(
-                authMethodOutbound: AuthenticationMethods.None,
+                authMethodOutbound: AuthenticationMethods.Bearer,
                 soapAuthenticationOptions: new SOAPAuthenticationOptions
                 {
                     TokenPlacement = new SoapTokenPlacementOptions

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
@@ -2,13 +2,18 @@ using KN.KI.LogAggregator.Library.Abstractions;
 using KN.KloudIdentity.Mapper;
 using KN.KloudIdentity.Mapper.Domain;
 using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Authentication;
 using KN.KloudIdentity.Mapper.Domain.Mapping;
+using KN.KloudIdentity.Mapper.MapperCore;
+using KN.KloudIdentity.Mapper.Utils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.SCIM;
 using Moq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 
 namespace KN.KloudIdentity.MapperTests.SOAPIntegration;
@@ -296,7 +301,199 @@ public class SOAPIntegrationUnitTests
         Assert.Equal("U-909", result!.Identifier);
     }
 
-    private static global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration CreateSut(TestHttpMessageHandler? handler = null)
+    [Fact]
+    public async Task ProvisionAsync_WithBasicAuth_SetsBasicAuthorizationHeader()
+    {
+        var handler = new TestHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""
+                                        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                                            <soap:Body>
+                                                <CreateUserResponse>
+                                                    <Identifier>U-1001</Identifier>
+                                                </CreateUserResponse>
+                                            </soap:Body>
+                                        </soap:Envelope>
+                                        """, Encoding.UTF8, "text/xml")
+                });
+
+        var sut = CreateSut(handler, "dXNlcjpwYXNz");
+        var appConfig = CreateAppConfig(
+                authMethodOutbound: AuthenticationMethods.Basic,
+                authDetails: new { Username = "user", Password = "pass" });
+
+        await sut.ProvisionAsync("<CreateUser />", appConfig, "corr-basic");
+
+        Assert.NotNull(handler.LastAuthorizationHeader);
+        Assert.Equal("Basic", handler.LastAuthorizationHeader!.Scheme);
+        Assert.Equal("dXNlcjpwYXNz", handler.LastAuthorizationHeader.Parameter);
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WithNtlmEnabledAndMissingCredentials_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig(
+                authMethodOutbound: AuthenticationMethods.None,
+                soapAuthenticationOptions: new SOAPAuthenticationOptions
+                {
+                    Transport = new BasicOrNtlmSoapAuthOptions
+                    {
+                        Enabled = true,
+                        UseNtlm = true,
+                        UseDefaultCredentials = false
+                    }
+                });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                sut.ProvisionAsync("<CreateUser />", appConfig, "corr-ntlm-invalid"));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WithWsSecurityUsernameToken_AddsWsseHeaderToPayload()
+    {
+        var handler = new TestHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""
+                                        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                                            <soap:Body>
+                                                <CreateUserResponse>
+                                                    <Identifier>U-2002</Identifier>
+                                                </CreateUserResponse>
+                                            </soap:Body>
+                                        </soap:Envelope>
+                                        """, Encoding.UTF8, "text/xml")
+                });
+
+        var sut = CreateSut(handler);
+        var appConfig = CreateAppConfig(
+                authMethodOutbound: AuthenticationMethods.None,
+                soapAuthenticationOptions: new SOAPAuthenticationOptions
+                {
+                    WsSecurity = new WsSecuritySoapAuthOptions
+                    {
+                        Enabled = true,
+                        Username = "ws-user",
+                        Password = "ws-pass",
+                        IncludeTimestamp = true
+                    }
+                });
+
+        const string payload = """
+                        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                            <soap:Body>
+                                <CreateUser />
+                            </soap:Body>
+                        </soap:Envelope>
+                        """;
+
+        await sut.ProvisionAsync(payload, appConfig, "corr-wsse");
+
+        Assert.Contains("wsse:Security", handler.LastRequestBody);
+        Assert.Contains("wsse:Username", handler.LastRequestBody);
+        Assert.Contains("ws-user", handler.LastRequestBody);
+        Assert.Contains("wsu:Timestamp", handler.LastRequestBody);
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WithTokenPlacement_AddsAuthorizationCustomHttpAndSoapHeaders()
+    {
+        var handler = new TestHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""
+                                        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                                            <soap:Body>
+                                                <CreateUserResponse>
+                                                    <Identifier>U-3003</Identifier>
+                                                </CreateUserResponse>
+                                            </soap:Body>
+                                        </soap:Envelope>
+                                        """, Encoding.UTF8, "text/xml")
+                });
+
+        var sut = CreateSut(handler, "token-123");
+        var appConfig = CreateAppConfig(
+                authMethodOutbound: AuthenticationMethods.None,
+                soapAuthenticationOptions: new SOAPAuthenticationOptions
+                {
+                    TokenPlacement = new SoapTokenPlacementOptions
+                    {
+                        Enabled = true,
+                        UseAuthorizationHeader = true,
+                        CustomHttpHeaders = new Dictionary<string, string>
+                        {
+                            ["X-SOAP-Token"] = "{{token}}"
+                        },
+                        SoapHeaderTemplate = "<auth:Token xmlns:auth='urn:test'>{{token}}</auth:Token>"
+                    }
+                });
+
+        const string payload = """
+                        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                            <soap:Body>
+                                <CreateUser />
+                            </soap:Body>
+                        </soap:Envelope>
+                        """;
+
+        await sut.ProvisionAsync(payload, appConfig, "corr-token");
+
+        Assert.NotNull(handler.LastAuthorizationHeader);
+        Assert.Equal("Bearer", handler.LastAuthorizationHeader!.Scheme);
+        Assert.Equal("token-123", handler.LastAuthorizationHeader.Parameter);
+        Assert.True(handler.LastHeaders.TryGetValue("X-SOAP-Token", out var customToken));
+        Assert.Equal("token-123", customToken);
+        Assert.Contains("auth:Token", handler.LastRequestBody);
+        Assert.Contains("token-123", handler.LastRequestBody);
+    }
+
+    [Fact]
+    public void ConfigureMapperServices_RegistersSoapAuthAndSoapIntegrationServices()
+    {
+        var services = new ServiceCollection();
+        services.Configure<AppSettings>(options =>
+        {
+            options.IntegrationMappings.DefaultIntegration[IntegrationMethods.SOAP.ToString()] = nameof(global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration);
+        });
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        services.ConfigureMapperServices(configuration);
+
+        Assert.Contains(services, d => d.ServiceType == typeof(IAuthStrategy) && d.ImplementationType == typeof(BearerAuthStratergy));
+        Assert.Contains(services, d => d.ServiceType == typeof(IIntegrationBase) && d.ImplementationType == typeof(global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration));
+        Assert.Contains(services, d => d.ServiceType == typeof(ISoapAuthApplier) && d.ImplementationType == typeof(SoapTransportAuthApplier));
+        Assert.Contains(services, d => d.ServiceType == typeof(ISoapAuthApplier) && d.ImplementationType == typeof(WsSecuritySoapAuthApplier));
+        Assert.Contains(services, d => d.ServiceType == typeof(ISoapAuthApplier) && d.ImplementationType == typeof(SoapTokenHeaderApplier));
+    }
+
+    [Fact]
+    public void IntegrationBaseFactory_WithSoapDefaultMapping_ResolvesSoapIntegration()
+    {
+        var soapIntegration = CreateSut();
+        var appSettings = Options.Create(new AppSettings
+        {
+            IntegrationMappings = new IntegrationMappings
+            {
+                DefaultIntegration = new Dictionary<string, string>
+                {
+                    [IntegrationMethods.SOAP.ToString()] = nameof(global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration)
+                }
+            }
+        });
+
+        var factory = new IntegrationBaseFactory(new List<IIntegrationBase> { soapIntegration }, appSettings);
+
+        var resolved = factory.GetIntegration(IntegrationMethods.SOAP, "soap-app");
+        Assert.IsType<global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration>(resolved);
+    }
+
+    private static global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration CreateSut(TestHttpMessageHandler? handler = null, string token = "test-token")
     {
         handler ??= new TestHttpMessageHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)
@@ -318,7 +515,7 @@ public class SOAPIntegrationUnitTests
         var authContextMock = new Mock<IAuthContext>();
         authContextMock
             .Setup(context => context.GetTokenAsync(It.IsAny<object>(), It.IsAny<SCIMDirections>()))
-            .Returns(Task.FromResult("test-token"));
+            .Returns(Task.FromResult(token));
 
         var options = Options.Create(new AppSettings());
         var configuration = new ConfigurationBuilder().Build();
@@ -333,13 +530,17 @@ public class SOAPIntegrationUnitTests
     }
 
     private static AppConfig CreateAppConfig(ICollection<SOAPTemplate>? templates = null,
-        ICollection<AttributeSchema>? schema = null)
+        ICollection<AttributeSchema>? schema = null,
+        AuthenticationMethods authMethodOutbound = AuthenticationMethods.None,
+        dynamic? authDetails = null,
+        SOAPAuthenticationOptions? soapAuthenticationOptions = null)
     {
         return new AppConfig
         {
             AppId = "soap-app",
             IntegrationMethodOutbound = IntegrationMethods.SOAP,
-            AuthenticationDetails = new { },
+            AuthenticationMethodOutbound = authMethodOutbound,
+            AuthenticationDetails = authDetails ?? new { },
             UserAttributeSchemas = schema ?? new List<AttributeSchema>(),
             UserURIs = new List<UserURIs>
             {
@@ -354,7 +555,8 @@ public class SOAPIntegrationUnitTests
                     Delete = new Uri("https://soap.example.test/users/delete")
                 }
             },
-            SOAPTemplates = templates
+            SOAPTemplates = templates,
+            SOAPAuthenticationOptions = soapAuthenticationOptions
         };
     }
 
@@ -368,6 +570,8 @@ public class SOAPIntegrationUnitTests
         }
 
         public string LastRequestBody { get; private set; } = string.Empty;
+        public AuthenticationHeaderValue? LastAuthorizationHeader { get; private set; }
+        public Dictionary<string, string> LastHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
@@ -375,6 +579,13 @@ public class SOAPIntegrationUnitTests
             LastRequestBody = request.Content == null
                 ? string.Empty
                 : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            LastAuthorizationHeader = request.Headers.Authorization;
+            LastHeaders = request.Headers
+                .ToDictionary(
+                    h => h.Key,
+                    h => string.Join(",", h.Value),
+                    StringComparer.OrdinalIgnoreCase);
 
             return _responseFactory(request);
         }

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ---
 page_type: sample
 languages:
-- csharp
+  - csharp
 products:
-- dotnetcore
-description: SCIM provisioning reference code  
+  - dotnetcore
+description: SCIM provisioning reference code
 urlFragment: "update-this-to-unique-url-stub"
 ---
 
 # SCIM Reference Code
 
-<!-- 
+<!--
 Guidelines on README format: https://review.docs.microsoft.com/help/onboard/admin/samples/concepts/readme-template?branch=master
 
 Guidance on onboarding samples to docs.microsoft.com/samples: https://review.docs.microsoft.com/help/onboard/admin/samples/process/onboarding?branch=master
@@ -23,15 +23,15 @@ The reference code provided in this repository will help you get started buildin
 > **[NOTE]**
 > This code is intended to help you get started building your SCIM endpoint and is provided "AS IS." It is intended as a reference and there is no guarantee of it being actively maintained or supported. [Contributions](https://github.com/AzureAD/SCIMReferenceCode/wiki/Contributing-Overview) from the community are welcome to help build and maintain the repo.
 
-## Capabilities 
+## Capabilities
 
-|Endpoint|Description|
-|---|---|
-|/Users|**Perform CRUD operations on a user resource:** <br/> 1. Create <br/> 2. Update <br/> 3. Delete <br/> 4. Get <br/> 5. List <br/> 6. Filter|
-|/Groups|**Perform CRUD operations on a group resource:** <br/> 1. Create <br/> 2. Update <br/> 3. Delete <br/> 4. Get <br/> 5. List <br/> 6. Filter |
-|/Schemas|**Retrieve one or more supported schemas.**<br/>The set of attributes of a resource supported by each service provider can vary. (e.g. Service Provider A supports “name”, “title”, and “emails” while Service Provider B supports “name”, “title”, and “phoneNumbers” for users).|
-|/ResourceTypes|**Retrieve supported resource types.**<br/>The number and types of resources supported by each service provider can vary. (e.g. Service Provider A supports users while Service Provider B supports users and groups).|
-|/ServiceProviderConfig|**Retrieve service provider's SCIM configuration**<br/>The SCIM features supported by each service provider can vary. (e.g. Service Provider A supports Patch operations while Service Provider B supports Patch Operations and Schema Discovery).|
+| Endpoint               | Description                                                                                                                                                                                                                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| /Users                 | **Perform CRUD operations on a user resource:** <br/> 1. Create <br/> 2. Update <br/> 3. Delete <br/> 4. Get <br/> 5. List <br/> 6. Filter                                                                                                                                         |
+| /Groups                | **Perform CRUD operations on a group resource:** <br/> 1. Create <br/> 2. Update <br/> 3. Delete <br/> 4. Get <br/> 5. List <br/> 6. Filter                                                                                                                                        |
+| /Schemas               | **Retrieve one or more supported schemas.**<br/>The set of attributes of a resource supported by each service provider can vary. (e.g. Service Provider A supports “name”, “title”, and “emails” while Service Provider B supports “name”, “title”, and “phoneNumbers” for users). |
+| /ResourceTypes         | **Retrieve supported resource types.**<br/>The number and types of resources supported by each service provider can vary. (e.g. Service Provider A supports users while Service Provider B supports users and groups).                                                             |
+| /ServiceProviderConfig | **Retrieve service provider's SCIM configuration**<br/>The SCIM features supported by each service provider can vary. (e.g. Service Provider A supports Patch operations while Service Provider B supports Patch Operations and Schema Discovery).                                 |
 
 ## Getting Started
 
@@ -42,37 +42,46 @@ The `Microsoft.SystemForCrossDomainIdentityManagement` project contains the code
 This reference code was developed as a .Net core MVC web API for SCIM provisioning. The three main folders are Schemas, Controllers, and Protocol.
 
 1. The **Schemas** folder includes:
-    * The models for the User and Group resources along with some abstract classes like Schematized for shared functionality.
-    * An Attributes folder which contains the class definitions for complex attributes of Users and Groups such as addresses.
+   - The models for the User and Group resources along with some abstract classes like Schematized for shared functionality.
+   - An Attributes folder which contains the class definitions for complex attributes of Users and Groups such as addresses.
 2. The **Service** folder contains logic for actions relating to the way resources are queried and updated.
-    * The reference code has services to return users and groups.
-    * The **controllers** folder contains the various SCIM endpoints. Resource controllers include HTTP verbs to perform CRUD operations on the resource (GET, POST, PUT, PATCH, DELETE). Controllers rely on services to perform the actions.
+   - The reference code has services to return users and groups.
+   - The **controllers** folder contains the various SCIM endpoints. Resource controllers include HTTP verbs to perform CRUD operations on the resource (GET, POST, PUT, PATCH, DELETE). Controllers rely on services to perform the actions.
 3. The **Protocol** folder contains logic for actions relating to the way resources are returned according to the SCIM RFC such as:
-    * Returning multiple resources as a list.
-    * Returning only specific resources based on a filter.
-    * Turning a query into a list of linked lists of single filters.
-    * Turning a PATCH request into an operation with attributes pertaining to the value path. 
-    * Defining the type of operation that can be used to apply changes to resource objects.
+   - Returning multiple resources as a list.
+   - Returning only specific resources based on a filter.
+   - Turning a query into a list of linked lists of single filters.
+   - Turning a PATCH request into an operation with attributes pertaining to the value path.
+   - Defining the type of operation that can be used to apply changes to resource objects.
 
 ### Contents
 
-| File/folder       | Description                                |
-|-------------------|--------------------------------------------|
-| `Microsoft.SystemForCrossDomainIdentityManagement`| Sample source code.|
-| `Microsoft.SCIM.WebHostSample`| Sample implementation of the SCIM library.|
-| `.gitignore`      | Define what to ignore at commit time.      |
-| `CHANGELOG.md`    | List of changes to the sample.             |
-| `CONTRIBUTING.md` | Guidelines for contributing to the sample. |
-| `README.md`       | This README file.                          |
-| `LICENSE`         | The license for the sample.                |
+| File/folder                                        | Description                                |
+| -------------------------------------------------- | ------------------------------------------ |
+| `Microsoft.SystemForCrossDomainIdentityManagement` | Sample source code.                        |
+| `Microsoft.SCIM.WebHostSample`                     | Sample implementation of the SCIM library. |
+| `.gitignore`                                       | Define what to ignore at commit time.      |
+| `CHANGELOG.md`                                     | List of changes to the sample.             |
+| `CONTRIBUTING.md`                                  | Guidelines for contributing to the sample. |
+| `README.md`                                        | This README file.                          |
+| `LICENSE`                                          | The license for the sample.                |
 
 ## Authorization
 
-The SCIM standard leaves authentication and authorization relatively open. You could use cookies, basic authentication, TLS client authentication, or any of the other methods listed [here](https://tools.ietf.org/html/rfc7644#section-2). You should take into consideration security and industry best practices when choosing an authentication/authorization method. Avoid insecure methods such as username and password in favor of more secure methods such as OAuth. Azure AD supports long-lived bearer tokens (for gallery and non-gallery applications) as well as the OAuth authorization grant (for applications published in the app gallery). Review the [wiki](https://github.com/AzureAD/SCIMReferenceCode/wiki/Authorization) for more details about the current authorization support that this reference code provides.   
+The SCIM standard leaves authentication and authorization relatively open. You could use cookies, basic authentication, TLS client authentication, or any of the other methods listed [here](https://tools.ietf.org/html/rfc7644#section-2). You should take into consideration security and industry best practices when choosing an authentication/authorization method. Avoid insecure methods such as username and password in favor of more secure methods such as OAuth. Azure AD supports long-lived bearer tokens (for gallery and non-gallery applications) as well as the OAuth authorization grant (for applications published in the app gallery). Review the [wiki](https://github.com/AzureAD/SCIMReferenceCode/wiki/Authorization) for more details about the current authorization support that this reference code provides.
 
 > **[NOTE]**
-> These authorization methods provided by this repo are solely for testing. When integrating with Azure AD, review the authorization guidance provided [here](https://docs.microsoft.com/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#authorization-for-provisioning-connectors-in-the-application-gallery). 
+> These authorization methods provided by this repo are solely for testing. When integrating with Azure AD, review the authorization guidance provided [here](https://docs.microsoft.com/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#authorization-for-provisioning-connectors-in-the-application-gallery).
 
+## SOAP Authentication Options
+
+For SOAP outbound integrations, you can now provide optional `SOAPAuthenticationOptions` in `AppConfig`.
+
+- `Transport`: basic/NTLM transport settings (`UseNtlm`, explicit credentials, or `UseDefaultCredentials`).
+- `WsSecurity`: WS-Security `UsernameToken` header values (`Username`, `Password`, optional `IncludeTimestamp`).
+- `TokenPlacement`: token delivery in `Authorization` header, custom HTTP headers, and/or custom SOAP header template.
+
+Backward compatibility is preserved. If `SOAPAuthenticationOptions` is not provided, existing `AuthenticationDetails` behavior continues to work.
 
 ## Contributing to the reference code
 
@@ -82,5 +91,6 @@ When submitting a pull request, a CLA bot will automatically determine whether y
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## Trademarks 
+## Trademarks
+
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow Microsoft’s Trademark & Brand Guidelines. Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.


### PR DESCRIPTION
This pull request introduces a new, extensible architecture for SOAP authentication, enabling support for multiple authentication modes (Basic, NTLM, WS-Security, and flexible token placement) while preserving backward compatibility and minimizing impact on unrelated modules. The changes are organized to allow incremental rollout, with clear separation of concerns and robust configuration options.

**Key changes include:**

### Architecture and Planning

* Added a detailed agent execution prompt (`.github/prompts/plan-soapAuthenticationArchitectureFit.prompt.md`) that outlines a phased plan for implementing SOAP authentication, including objectives, constraints, phase breakdowns, validation commands, and output requirements.

### Configuration & Contracts

* Introduced a new `SOAPAuthenticationOptions` record and related option types (`BasicOrNtlmSoapAuthOptions`, `WsSecuritySoapAuthOptions`, `SoapTokenPlacementOptions`) in `KN.KloudIdentity.Mapper.Domain/Application/SOAPAuthenticationOptions.cs` to capture all SOAP authentication configuration in a strongly-typed, backward-compatible manner.
* Extended the `AppConfig` record to include an optional `SOAPAuthenticationOptions` property, enabling per-integration configuration of authentication modes.

### Extensibility & Core Interfaces

* Defined the `ISoapAuthApplier` interface and `SoapAuthContext` context object in `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPAuth/ISoapAuthApplier.cs`, establishing a pluggable seam for applying different authentication strategies to SOAP requests.

### Concrete Auth Mode Implementations

* Implemented `SoapTransportAuthApplier` for handling Basic and NTLM transport authentication, as well as token placement in HTTP headers, with support for both explicit and default credentials.
* Implemented `WsSecuritySoapAuthApplier` for injecting WS-Security `UsernameToken` (plain text) and optional timestamp into the SOAP header, following the WS-Security specification.
* Implemented `SoapTokenHeaderApplier` for injecting tokens into custom SOAP header fragments, supporting flexible placement via templates and placeholders.

### Integration & Usage

* Refactored `SOAPIntegration` to compose and invoke all registered `ISoapAuthApplier` implementations in the request pipeline, ensuring that authentication is applied according to the resolved configuration. The constructor now accepts an optional list of appliers, defaulting to the three new implementations. The request flow now builds a `SoapAuthContext`, applies all appliers, and sends the modified SOAP request. [[1]](diffhunk://#diff-3075972bf2217e7ab24fac5306b6c1893222a2fcc3853f8e4c0d3d1014140829R34-R56) [[2]](diffhunk://#diff-3075972bf2217e7ab24fac5306b6c1893222a2fcc3853f8e4c0d3d1014140829L177-R209) [[3]](diffhunk://#diff-3075972bf2217e7ab24fac5306b6c1893222a2fcc3853f8e4c0d3d1014140829R4-R13)

These changes lay the foundation for robust, testable, and extensible SOAP authentication, while maintaining backward compatibility and minimizing disruption to existing integrations.