### PR TITLE
Refactor user creation command handling

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/LinuxIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/LinuxIntegration.cs
@@ -130,7 +130,8 @@ public class LinuxIntegration : IIntegrationBase
         {
             { "Username", GetValueFromResource(schema, resource, "Username") },
             { "UID", GetValueFromResource(schema, resource, "UID") },
-            { "Identifier", GetValueFromResource(schema, resource, "Identifier", true) }
+            { "Identifier", GetValueFromResource(schema, resource, "Identifier", true) } ,
+            { "GroupName", GetValueFromResource(schema, resource, "GroupName", true) }
         };
 
         return await Task.FromResult(valuesForCommand);
@@ -179,8 +180,23 @@ public class LinuxIntegration : IIntegrationBase
 
         Dictionary<string, string> valuesForCommand = payload;
 
-        string command =
-            $"sudo useradd -u {valuesForCommand["UID"]} -c \"{valuesForCommand["Identifier"]}\" {valuesForCommand["Username"]}";
+        string groupName = valuesForCommand["GroupName"];
+
+        string command = string.Empty;
+
+        if (!string.IsNullOrEmpty(groupName) && groupName == "sudo")
+        {
+            command = $"sudo useradd -u {valuesForCommand["UID"]} " +
+                $"-c \"{valuesForCommand["Identifier"]}\" {valuesForCommand["Username"]} " +
+                $"&& sudo passwd -d {valuesForCommand["Username"]} " +
+                $"&& sudo usermod -aG sudo {valuesForCommand["Username"]}";             
+        }
+        else
+        {
+            command = $"sudo useradd -u {valuesForCommand["UID"]} " +
+            $"-c \"{valuesForCommand["Identifier"]}\" {valuesForCommand["Username"]} " +
+            $"&& sudo passwd -d {valuesForCommand["Username"]}";
+        }       
 
         LinuxRequestMessage linuxRequestMessage = new LinuxRequestMessage(
             appConfig.IntegrationDetails,


### PR DESCRIPTION
This pull request enhances the Linux integration logic to support assigning new users to the `sudo` group when specified. The main changes involve updating the payload mapping and command construction to handle the optional `GroupName` attribute.

**Linux user creation improvements:**

* Added support for the optional `GroupName` attribute in the payload mapping by retrieving its value from the resource and including it in the command parameters.
* Modified the user creation command logic to check if `GroupName` is set to `sudo`. If so, the command now adds the new user to the `sudo` group after creation; otherwise, it performs standard user creation.