### PR TITLE
Enhance user creation to support dynamic groups

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/LinuxIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/LinuxIntegration.cs
@@ -184,12 +184,12 @@ public class LinuxIntegration : IIntegrationBase
 
         string command = string.Empty;
 
-        if (!string.IsNullOrEmpty(groupName) && groupName == "sudo")
+        if (!string.IsNullOrEmpty(groupName))
         {
             command = $"sudo useradd -u {valuesForCommand["UID"]} " +
                 $"-c \"{valuesForCommand["Identifier"]}\" {valuesForCommand["Username"]} " +
                 $"&& sudo passwd -d {valuesForCommand["Username"]} " +
-                $"&& sudo usermod -aG sudo {valuesForCommand["Username"]}";             
+                $"&& sudo usermod -aG {valuesForCommand["GroupName"]} {valuesForCommand["Username"]}";             
         }
         else
         {


### PR DESCRIPTION
This pull request updates the logic for constructing the Linux user creation command in the `LinuxIntegration.cs` file. The main change is to generalize group assignment during user creation, allowing any group name (not just "sudo") to be used.

**Integration command improvements:**

* The user creation command now assigns the user to the group specified by `GroupName`, instead of hardcoding "sudo", making the logic more flexible for different group assignments.