### PR TITLE
Support disconnected app provisioning through metaverse integration

### DIFF
--- a/KN.KloudIdentity.Mapper.Domain/Application/ActionNames.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/ActionNames.cs
@@ -7,5 +7,7 @@ public enum ActionNames
     CREATE = 2,
     EDIT = 3,
     DELETE = 4,
-    PATCH = 5
+    LIST = 5,
+    BASE = 6,
+    PATCH = 7
 }

--- a/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
@@ -1,11 +1,13 @@
 ﻿using KN.KloudIdentity.Mapper.Domain.Authentication;
 using KN.KloudIdentity.Mapper.Domain.ExternalEndpoint;
+using KN.KloudIdentity.Mapper.Domain.Itsm;
 using KN.KloudIdentity.Mapper.Domain.Mapping;
 
 namespace KN.KloudIdentity.Mapper.Domain.Application;
 
 public record AppConfig
 {
+    public string TenantId { get; init; }
     public string AppId { get; init; } = string.Empty;
     public string AppName { get; init; } = string.Empty;
     public bool IsEnabled { get; init; }
@@ -25,7 +27,7 @@ public record AppConfig
 
     public ICollection<Action> Actions { get; set; } = [];
     public AuthenticationFlow? AuthenticationFlow { get; set; }
-
+    public ItsmSettings ItsmConfigurations { get; set; } = new ItsmSettings();
 
     /// <summary>
     /// Validates that UserURIs is set when IntegrationMethodOutbound is REST.

--- a/KN.KloudIdentity.Mapper.Domain/Application/IntegrationMethods.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/IntegrationMethods.cs
@@ -9,5 +9,5 @@ public enum IntegrationMethods
     Linux = 4,
     AS400 = 5,
     SQL = 6,
-    Disconnected = 7
+    ITSM = 7
 }

--- a/KN.KloudIdentity.Mapper.Domain/Application/IntegrationMethods.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/IntegrationMethods.cs
@@ -9,4 +9,5 @@ public enum IntegrationMethods
     Linux = 4,
     AS400 = 5,
     SQL = 6,
+    Disconnected = 7
 }

--- a/KN.KloudIdentity.Mapper.Domain/Itsm/ItsmIntegrationMethod.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Itsm/ItsmIntegrationMethod.cs
@@ -1,0 +1,10 @@
+namespace KN.KloudIdentity.Mapper.Domain.Itsm;
+
+public class ItsmIntegrationMethod
+{
+    public Guid Id { get; set; }
+    public string TenantId { get; set; } = string.Empty;
+    public string AppId { get; set; } = string.Empty;
+    public int ITSMSettingId { get; set; }
+    public Dictionary<string, string> AdditionalProperties { get; set; } = [];
+}

--- a/KN.KloudIdentity.Mapper.Domain/Itsm/ItsmSettings.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Itsm/ItsmSettings.cs
@@ -1,0 +1,9 @@
+namespace KN.KloudIdentity.Mapper.Domain.Itsm;
+
+public class ItsmSettings
+{
+    public int Id { get; set; }
+    public string TenantId { get; set; } = null!;
+    public ServiceProvider ServiceProvider { get; set; }
+    public List<ServiceProviderUrl> ServiceProviderUrls { get; set; } = [];
+}

--- a/KN.KloudIdentity.Mapper.Domain/Itsm/ServiceProvider.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Itsm/ServiceProvider.cs
@@ -1,0 +1,12 @@
+namespace KN.KloudIdentity.Mapper.Domain.Itsm;
+
+public enum ServiceProvider
+{
+    NoneDefined = 0,
+    ServiceNow = 1,
+    JiraCloud = 2,
+    JiraServiceManagement = 3,
+    Freshservice = 4,
+    Zendesk = 5,
+    BMCRemedy = 6
+}

--- a/KN.KloudIdentity.Mapper.Domain/Itsm/ServiceProviderUrl.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Itsm/ServiceProviderUrl.cs
@@ -1,0 +1,10 @@
+using KN.KloudIdentity.Mapper.Domain.Application;
+
+namespace KN.KloudIdentity.Mapper.Domain.Itsm;
+
+public class ServiceProviderUrl
+{
+    public int Id { get; set; }
+    public ActionNames ActionName { get; set; }
+    public string? RequestUrl { get; set; }
+}

--- a/KN.KloudIdentity.Mapper.Domain/Mapping/AttributeSchema.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Mapping/AttributeSchema.cs
@@ -11,4 +11,5 @@ public record AttributeSchema : SchemaBase
     /// Destination field type length.
     /// </summary>
     public int? DestinationTypeLength { get; init; }
+    public int? ServiceProviderUrlId { get; init; }
 }

--- a/KN.KloudIdentity.Mapper.Domain/Messaging/ActionTypeEnum.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Messaging/ActionTypeEnum.cs
@@ -9,5 +9,10 @@ public enum ActionType
     GetInboundConfigurations,
     ListAs400Groups,
     LicenseStatusCheck,
-    ListApplicationConfigs
+    ListApplicationConfigs,
+    DisconnectedUserProvisioning,
+    DisconnectedUserRetrieval,
+    DisconnectedUserUpdate,
+    DisconnectedUserReplace,
+    DisconnectedUserDeletion
 }

--- a/KN.KloudIdentity.Mapper.Infrastructure/DI/DependencyInjection.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/DI/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
+using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Commands;
 using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Queries;
 using KN.KloudIdentity.Mapper.Infrastructure.Persistence.Abstractions;
 using KN.KloudIdentity.Mapper.Infrastructure.Persistence.Repositories;
@@ -27,6 +28,7 @@ public static class DependencyInjection
         
         services.AddScoped<IAppConfigSnapshotRepository, AppConfigSnapshotRepository>();
         services.AddScoped<IListApplicationConfigsQuery, ListApplicationConfigsQuery>();
+        services.AddScoped<IMetaverseIntegrationClient, MetaverseIntegrationClient>();
         
         return services;
     }

--- a/KN.KloudIdentity.Mapper.Infrastructure/Exceptions/MetaverseIntegrationException.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/Exceptions/MetaverseIntegrationException.cs
@@ -1,0 +1,17 @@
+namespace KN.KloudIdentity.Mapper.Infrastructure.Exceptions;
+
+/// <summary>
+/// Represents an error returned from or encountered while communicating with the metaverse integration service.
+/// </summary>
+public class MetaverseIntegrationException : Exception
+{
+    public MetaverseIntegrationException(string message)
+        : base(message)
+    {
+    }
+
+    public MetaverseIntegrationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
@@ -7,25 +7,25 @@ public interface IMetaverseIntegrationClient
     /// <summary>
     /// Sends a request to the metaverse integration service to perform a create operation for the specified application and payload.
     /// </summary>
-    Task<T> CreateAsync<T>(string appId, object payload, string correlationId, CancellationToken cancellationToken = default);
+    Task<T> CreateAsync<T>(string tenantId, string appId, object payload, string correlationId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sends a request to the metaverse integration service to perform a get operation for the specified application and identifier.
     /// </summary>
-    Task<T> GetAsync<T>(string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
+    Task<T> GetAsync<T>(string tenantId, string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sends a request to the metaverse integration service to perform an update operation for the specified application, identifier, and payload.
     /// </summary>
-    Task<T> UpdateAsync<T>(string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
+    Task<T> UpdateAsync<T>(string tenantId, string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sends a request to the metaverse integration service to perform a replace operation for the specified application, identifier, and payload.
     /// </summary>
-    Task<T> ReplaceAsync<T>(string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
+    Task<T> ReplaceAsync<T>(string tenantId, string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sends a request to the metaverse integration service to perform a delete operation for the specified application and identifier.
     /// </summary>
-    Task<T> DeleteAsync<T>(string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
+    Task<T> DeleteAsync<T>(string tenantId, string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
 }

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
@@ -1,0 +1,16 @@
+// File: Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
+
+namespace KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
+
+public interface IMetaverseIntegrationClient
+{
+    Task<T> CreateAsync<T>(string appId, object payload, string correlationId, CancellationToken cancellationToken = default);
+
+    Task<T> GetAsync<T>(string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
+
+    Task<T> UpdateAsync<T>(string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
+
+    Task<T> ReplaceAsync<T>(string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
+
+    Task<T> DeleteAsync<T>(string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
+}

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IMetaverseIntegrationClient.cs
@@ -4,13 +4,28 @@ namespace KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
 
 public interface IMetaverseIntegrationClient
 {
+    /// <summary>
+    /// Sends a request to the metaverse integration service to perform a create operation for the specified application and payload.
+    /// </summary>
     Task<T> CreateAsync<T>(string appId, object payload, string correlationId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a request to the metaverse integration service to perform a get operation for the specified application and identifier.
+    /// </summary>
     Task<T> GetAsync<T>(string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a request to the metaverse integration service to perform an update operation for the specified application, identifier, and payload.
+    /// </summary>
     Task<T> UpdateAsync<T>(string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a request to the metaverse integration service to perform a replace operation for the specified application, identifier, and payload.
+    /// </summary>
     Task<T> ReplaceAsync<T>(string appId, string identifier, object payload, string correlationId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a request to the metaverse integration service to perform a delete operation for the specified application and identifier.
+    /// </summary>
     Task<T> DeleteAsync<T>(string appId, string identifier, string correlationId, CancellationToken cancellationToken = default);
 }

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
@@ -82,7 +82,8 @@ public class MetaverseIntegrationClient(
         {
             var response = await requestClient.GetResponse<IInterserviceResponseMsg>(
                 message,
-                cancellationToken
+                timeout: RequestTimeout.After(s: 60),
+                cancellationToken: cancellationToken
             );
 
             return (T)response;

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using KN.KI.RabbitMQ.MessageContracts;
 using KN.KloudIdentity.Mapper.Domain.Messaging;
+using KN.KloudIdentity.Mapper.Infrastructure.Exceptions;
 using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
 using MassTransit;
 using Serilog;
@@ -16,47 +17,53 @@ public class MetaverseIntegrationClient(
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public Task<T> CreateAsync<T>(
+        string tenantId,
         string appId,
         object payload,
         string correlationId,
         CancellationToken cancellationToken
-    ) => SendAsync<T>(appId, new { appId, payload }, correlationId, ActionType.DisconnectedUserProvisioning, cancellationToken);
+    ) => SendAsync<T>(tenantId, appId, new {tenantId, appId, payload }, correlationId, ActionType.DisconnectedUserProvisioning, cancellationToken);
 
     public Task<T> GetAsync<T>(
+        string tenantId,
         string appId,
         string identifier,
         string correlationId,
         CancellationToken cancellationToken
-    ) => SendAsync<T>(appId, new { appId, identifier }, correlationId, ActionType.DisconnectedUserRetrieval, cancellationToken);
+    ) => SendAsync<T>(tenantId, appId, new {tenantId, appId, identifier }, correlationId, ActionType.DisconnectedUserRetrieval, cancellationToken);
 
     public Task<T> UpdateAsync<T>(
+        string tenantId,
         string appId,
         string identifier,
         object payload,
         string correlationId,
         CancellationToken cancellationToken
-    ) => SendAsync<T>(appId, new { appId, identifier, payload }, correlationId, ActionType.DisconnectedUserUpdate, cancellationToken);
+    ) => SendAsync<T>(tenantId, appId, new { tenantId, appId, identifier, payload }, correlationId, ActionType.DisconnectedUserUpdate, cancellationToken);
 
     public Task<T> ReplaceAsync<T>(
+        string tenantId,
         string appId,
         string identifier,
         object payload,
         string correlationId,
         CancellationToken cancellationToken
-    ) => SendAsync<T>(appId, new { appId, identifier, payload }, correlationId, ActionType.DisconnectedUserReplace, cancellationToken);
+    ) => SendAsync<T>(tenantId, appId, new {tenantId, appId, identifier, payload }, correlationId, ActionType.DisconnectedUserReplace, cancellationToken);
 
     public Task<T> DeleteAsync<T>(
+        string tenantId,
         string appId,
         string identifier,
         string correlationId,
         CancellationToken cancellationToken
-    ) => SendAsync<T>(appId, new { appId, identifier }, correlationId, ActionType.DisconnectedUserDeletion, cancellationToken);
+    ) => SendAsync<T>(tenantId, appId, new {tenantId, appId, identifier }, correlationId, ActionType.DisconnectedUserDeletion, cancellationToken);
 
     /// <summary>
     /// Sends a request message to the metaverse integration service and processes the response.
     /// This method is used by all the public methods to perform the actual communication with the metaverse service.
     /// </summary>
     private async Task<T> SendAsync<T>(
+        string tenantId,
         string appId,
         object request,
         string correlationId,
@@ -78,11 +85,11 @@ public class MetaverseIntegrationClient(
                 cancellationToken
             );
 
-            return ProcessResponse<T>(response.Message);
+            return (T)response;
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Metaverse request failed | AppId: {AppId}", appId);
+            Log.Error(ex, "Metaverse request failed | tenantId:{tenantId} AppId: {AppId}",  tenantId, appId);
             throw;
         }
     }
@@ -91,12 +98,12 @@ public class MetaverseIntegrationClient(
     {
         if (response is null || response.IsError == true)
         {
-            Log.Error("Response error: {Error}", response?.ErrorMessage);
-            throw new InvalidOperationException(response?.ErrorMessage ?? "Unknown error");
+            Log.Error("MetaverseIntegrationClient: Response error: {Error}", response?.ErrorMessage);
+            throw new MetaverseIntegrationException(response?.ErrorMessage ?? "Unknown error");
         }
 
         if (string.IsNullOrWhiteSpace(response.Message))
-            throw new InvalidOperationException("Response message is empty");
+            throw new MetaverseIntegrationException("MetaverseIntegrationClient: Response message is empty");
 
         return JsonSerializer.Deserialize<T>(response.Message, JsonOptions)!;
     }

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
@@ -1,0 +1,99 @@
+// File: Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
+
+using System.Text.Json;
+using KN.KI.RabbitMQ.MessageContracts;
+using KN.KloudIdentity.Mapper.Domain.Messaging;
+using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
+using MassTransit;
+using Serilog;
+
+namespace KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Commands;
+
+public class MetaverseIntegrationClient(
+    IRequestClient<IMetaverseServiceRequestMsg> requestClient
+) : IMetaverseIntegrationClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public Task<T> CreateAsync<T>(
+        string appId,
+        object payload,
+        string correlationId,
+        CancellationToken cancellationToken
+    ) => SendAsync<T>(appId, new { appId, payload }, correlationId, ActionType.DisconnectedUserProvisioning, cancellationToken);
+
+    public Task<T> GetAsync<T>(
+        string appId,
+        string identifier,
+        string correlationId,
+        CancellationToken cancellationToken
+    ) => SendAsync<T>(appId, new { appId, identifier }, correlationId, ActionType.DisconnectedUserRetrieval, cancellationToken);
+
+    public Task<T> UpdateAsync<T>(
+        string appId,
+        string identifier,
+        object payload,
+        string correlationId,
+        CancellationToken cancellationToken
+    ) => SendAsync<T>(appId, new { appId, identifier, payload }, correlationId, ActionType.DisconnectedUserUpdate, cancellationToken);
+
+    public Task<T> ReplaceAsync<T>(
+        string appId,
+        string identifier,
+        object payload,
+        string correlationId,
+        CancellationToken cancellationToken
+    ) => SendAsync<T>(appId, new { appId, identifier, payload }, correlationId, ActionType.DisconnectedUserReplace, cancellationToken);
+
+    public Task<T> DeleteAsync<T>(
+        string appId,
+        string identifier,
+        string correlationId,
+        CancellationToken cancellationToken
+    ) => SendAsync<T>(appId, new { appId, identifier }, correlationId, ActionType.DisconnectedUserDeletion, cancellationToken);
+
+    private async Task<T> SendAsync<T>(
+        string appId,
+        object request,
+        string correlationId,
+        ActionType action,
+        CancellationToken cancellationToken
+    )
+    {
+        var message = new MetaverseServiceRequestMsg(
+            JsonSerializer.Serialize(request, JsonOptions),
+            action.ToString(), // critical fix
+            correlationId,
+            null
+        );
+
+        try
+        {
+            var response = await requestClient.GetResponse<IInterserviceResponseMsg>(
+                message,
+                cancellationToken
+            );
+
+            return ProcessResponse<T>(response.Message);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Metaverse request failed | AppId: {AppId}", appId);
+            throw;
+        }
+    }
+
+    private static T ProcessResponse<T>(IInterserviceResponseMsg? response)
+    {
+        if (response is null || response.IsError == true)
+        {
+            Log.Error("Response error: {Error}", response?.ErrorMessage);
+            throw new InvalidOperationException(response?.ErrorMessage ?? "Unknown error");
+        }
+
+        if (string.IsNullOrWhiteSpace(response.Message))
+            throw new InvalidOperationException("Response message is empty");
+
+        return JsonSerializer.Deserialize<T>(response.Message, JsonOptions)!;
+    }
+}

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
@@ -86,7 +86,7 @@ public class MetaverseIntegrationClient(
                 cancellationToken: cancellationToken
             );
 
-            return (T)response;
+            return ProcessResponse<T>(response.Message);
         }
         catch (Exception ex)
         {

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Commands/MetaverseIntegrationClient.cs
@@ -52,6 +52,10 @@ public class MetaverseIntegrationClient(
         CancellationToken cancellationToken
     ) => SendAsync<T>(appId, new { appId, identifier }, correlationId, ActionType.DisconnectedUserDeletion, cancellationToken);
 
+    /// <summary>
+    /// Sends a request message to the metaverse integration service and processes the response.
+    /// This method is used by all the public methods to perform the actual communication with the metaverse service.
+    /// </summary>
     private async Task<T> SendAsync<T>(
         string appId,
         object request,

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/DisconnectedIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/DisconnectedIntegration.cs
@@ -10,11 +10,12 @@ namespace KN.KloudIdentity.Mapper.MapperCore;
 /// </summary>
 public class DisconnectedIntegration(
     IMetaverseIntegrationClient metaverseIntegrationClient
-    ) : IIntegrationBase
+) : IIntegrationBaseV2
 {
-    public IntegrationMethods IntegrationMethod { get; init; } = IntegrationMethods.Disconnected;
+    public IntegrationMethods IntegrationMethod { get; init; } = IntegrationMethods.ITSM;
 
-    public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource,
+    public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema,
+        Core2EnterpriseUser resource,
         CancellationToken cancellationToken = default)
     {
         var payload = JSONParserUtilV2<Resource>.Parse(schema, resource);
@@ -22,6 +23,7 @@ public class DisconnectedIntegration(
         {
             payload["identifier"] = resource.Identifier;
         }
+
         return await Task.FromResult(payload);
     }
 
@@ -29,17 +31,24 @@ public class DisconnectedIntegration(
     /// Handles user provisioning through the pipeline when the application interacts with the internal metaverse service.
     /// Authentication is not required in this scenario.
     /// </summary>
-    public async Task<dynamic> GetAuthenticationAsync(AppConfig config, SCIMDirections direction = SCIMDirections.Outbound,
+    public async Task<dynamic> GetAuthenticationAsync(AppConfig config,
+        SCIMDirections direction = SCIMDirections.Outbound,
         CancellationToken cancellationToken = default, params dynamic[] args)
     {
-       return await Task.FromResult<object>(null!);
+        return await Task.FromResult<object>(null!);
     }
-    
+
     public async Task<Core2EnterpriseUser?> ProvisionAsync(dynamic payload, AppConfig appConfig, string correlationId,
         CancellationToken cancellationToken = default)
     {
-        var result =await metaverseIntegrationClient.CreateAsync<object>(appConfig.AppId, payload, correlationId, cancellationToken);
-       // [To-DO] Develop later
+        var result = await metaverseIntegrationClient.CreateAsync<object>(
+            appConfig.TenantId,
+            appConfig.AppId,
+            payload,
+            correlationId,
+            cancellationToken);
+
+        // [To-DO] Develop later
         return new Core2EnterpriseUser { Identifier = payload.identifier };
     }
 
@@ -52,26 +61,83 @@ public class DisconnectedIntegration(
     public async Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, string correlationId,
         CancellationToken cancellationToken = default)
     {
-        var response = await metaverseIntegrationClient.GetAsync<object>(appConfig.AppId, identifier, correlationId, cancellationToken);
+        var response = await metaverseIntegrationClient.GetAsync<object>(appConfig.TenantId,
+            appConfig.AppId,
+            identifier,
+            correlationId,
+            cancellationToken);
+
         // [To-DO] Develop later
-        return  new Core2EnterpriseUser { Identifier = identifier };
+        return new Core2EnterpriseUser { Identifier = identifier };
     }
 
-    public async Task ReplaceAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig, string correlationId)
+    public async Task ReplaceAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig,
+        string correlationId)
     {
-        var response = await metaverseIntegrationClient.ReplaceAsync<object>(appConfig.AppId, resource.Identifier, payload, correlationId);
+        var response = await metaverseIntegrationClient.ReplaceAsync<object>(appConfig.TenantId,
+            appConfig.AppId,
+            resource.Identifier,
+            payload,
+            correlationId);
         // [To-DO] Develop later
     }
 
-    public async Task UpdateAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig, string correlationId)
+    public async Task UpdateAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig,
+        string correlationId)
     {
-        var response = await metaverseIntegrationClient.UpdateAsync<object>(appConfig.AppId, resource.Identifier, payload, correlationId);
+        var response = await metaverseIntegrationClient.UpdateAsync<object>(appConfig.TenantId,
+            appConfig.AppId,
+            resource.Identifier,
+            payload,
+            correlationId);
+
         // [To-DO] Develop later
     }
 
     public async Task DeleteAsync(string identifier, AppConfig appConfig, string correlationId)
     {
-        var response = await metaverseIntegrationClient.DeleteAsync<object>(appConfig.AppId, identifier, correlationId);
+        var response = await metaverseIntegrationClient.DeleteAsync<object>(appConfig.TenantId,
+            appConfig.AppId,
+            identifier,
+            correlationId);
         //[To-DO] Develop later
     }
+
+    #region Not Implemented: Action-based methods (not required for DisconnectedIntegration)
+
+    public Task<Core2EnterpriseUser?> ProvisionAsync(dynamic payload, string appId, AppConfig appConfig,
+        ActionStep actionStep, string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based provisioning is not supported for disconnected applications.");
+    }
+
+    public Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, ActionStep actionStep,
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based retrieval is not supported for disconnected applications.");
+    }
+
+    public Task<Core2EnterpriseUser> ReplaceAsync(dynamic payload, Core2EnterpriseUser resource, string appId,
+        AppConfig appConfig,
+        ActionStep actionStep, string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based replacement is not supported for disconnected applications.");
+    }
+
+    public Task UpdateAsync(dynamic payload, Core2EnterpriseUser resource, string appId, AppConfig appConfig,
+        ActionStep actionStep, string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based update is not supported for disconnected applications.");
+    }
+
+    public Task DeleteAsync(string identifier, string appId, AppConfig appConfig, ActionStep actionStep,
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based deletion is not supported for disconnected applications.");
+    }
+
+    #endregion
 }

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/DisconnectedIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/DisconnectedIntegration.cs
@@ -1,0 +1,67 @@
+using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Mapping;
+using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
+using Microsoft.SCIM;
+
+namespace KN.KloudIdentity.Mapper.MapperCore;
+
+public class DisconnectedIntegration(
+    IMetaverseIntegrationClient metaverseIntegrationClient
+    ) : IIntegrationBase
+{
+    public IntegrationMethods IntegrationMethod { get; init; } = IntegrationMethods.Disconnected;
+
+    public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource,
+        CancellationToken cancellationToken = default)
+    {
+        var payload = JSONParserUtilV2<Resource>.Parse(schema, resource);
+        
+        return await Task.FromResult(payload);
+    }
+
+    public async Task<dynamic> GetAuthenticationAsync(AppConfig config, SCIMDirections direction = SCIMDirections.Outbound,
+        CancellationToken cancellationToken = default, params dynamic[] args)
+    {
+       return await Task.FromResult<object>(null!);
+    }
+
+    public async Task<Core2EnterpriseUser?> ProvisionAsync(dynamic payload, AppConfig appConfig, string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        var result =await metaverseIntegrationClient.CreateAsync<object>(appConfig.AppId, payload, correlationId, cancellationToken);
+       // [To-DO] Develop later
+        return await Task.FromResult<Core2EnterpriseUser?>(result);
+    }
+
+    public Task<(bool, string[])> ValidatePayloadAsync(dynamic payload, AppConfig appConfig, string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult((true, Array.Empty<string>()));
+    }
+
+    public async Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await metaverseIntegrationClient.GetAsync<object>(appConfig.AppId, identifier, correlationId, cancellationToken);
+        // [To-DO] Develop later
+        return  new Core2EnterpriseUser { Identifier = identifier };
+    }
+
+    public async Task ReplaceAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig, string correlationId)
+    {
+        var response = await metaverseIntegrationClient.ReplaceAsync<object>(appConfig.AppId, resource.Identifier, payload, correlationId);
+        // [To-DO] Develop later
+    }
+
+    public async Task UpdateAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig, string correlationId)
+    {
+        var response = await metaverseIntegrationClient.UpdateAsync<object>(appConfig.AppId, resource.Identifier, payload, correlationId);
+        // [To-DO] Develop later
+    }
+
+    public async Task DeleteAsync(string identifier, AppConfig appConfig, string correlationId)
+    {
+        var response = await metaverseIntegrationClient.DeleteAsync<object>(appConfig.AppId, identifier, correlationId);
+        //[To-DO] Develop later
+    }
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/DisconnectedIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/DisconnectedIntegration.cs
@@ -5,6 +5,9 @@ using Microsoft.SCIM;
 
 namespace KN.KloudIdentity.Mapper.MapperCore;
 
+/// <summary>
+/// The DisconnectedIntegration class is intended for use with applications that lack user provisioning functionality.
+/// </summary>
 public class DisconnectedIntegration(
     IMetaverseIntegrationClient metaverseIntegrationClient
     ) : IIntegrationBase
@@ -15,22 +18,29 @@ public class DisconnectedIntegration(
         CancellationToken cancellationToken = default)
     {
         var payload = JSONParserUtilV2<Resource>.Parse(schema, resource);
-        
+        if (!payload.ContainsKey("identifier"))
+        {
+            payload["identifier"] = resource.Identifier;
+        }
         return await Task.FromResult(payload);
     }
 
+    /// <summary>
+    /// Handles user provisioning through the pipeline when the application interacts with the internal metaverse service.
+    /// Authentication is not required in this scenario.
+    /// </summary>
     public async Task<dynamic> GetAuthenticationAsync(AppConfig config, SCIMDirections direction = SCIMDirections.Outbound,
         CancellationToken cancellationToken = default, params dynamic[] args)
     {
        return await Task.FromResult<object>(null!);
     }
-
+    
     public async Task<Core2EnterpriseUser?> ProvisionAsync(dynamic payload, AppConfig appConfig, string correlationId,
         CancellationToken cancellationToken = default)
     {
         var result =await metaverseIntegrationClient.CreateAsync<object>(appConfig.AppId, payload, correlationId, cancellationToken);
        // [To-DO] Develop later
-        return await Task.FromResult<Core2EnterpriseUser?>(result);
+        return new Core2EnterpriseUser { Identifier = payload.identifier };
     }
 
     public Task<(bool, string[])> ValidatePayloadAsync(dynamic payload, AppConfig appConfig, string correlationId,

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/ITSMIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/ITSMIntegration.cs
@@ -8,7 +8,7 @@ namespace KN.KloudIdentity.Mapper.MapperCore;
 /// <summary>
 /// The DisconnectedIntegration class is intended for use with applications that lack user provisioning functionality.
 /// </summary>
-public class DisconnectedIntegration(
+public class ITSMIntegration(
     IMetaverseIntegrationClient metaverseIntegrationClient
 ) : IIntegrationBaseV2
 {
@@ -47,9 +47,9 @@ public class DisconnectedIntegration(
             payload,
             correlationId,
             cancellationToken);
-
-        // [To-DO] Develop later
-        return new Core2EnterpriseUser { Identifier = payload.identifier };
+        
+        var identifier = payload["identifier"].ToString();
+        return new Core2EnterpriseUser { Identifier = identifier };
     }
 
     public Task<(bool, string[])> ValidatePayloadAsync(dynamic payload, AppConfig appConfig, string correlationId,

--- a/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
@@ -206,11 +206,27 @@ public class CreateUserV4 : ProvisioningBase, ICreateResourceV2
 
     private IList<AttributeSchema> GetUserAttributes(ICollection<AttributeSchema> userAttributeSchemas, IntegrationMethods? integrationMethodOutbound)
     {
+        if (userAttributeSchemas == null)
+            return new List<AttributeSchema>();
+
         switch (integrationMethodOutbound)
         {
             case IntegrationMethods.REST:
             case IntegrationMethods.SQL:
-                return userAttributeSchemas.Where(x => x.HttpRequestType == HttpRequestTypes.POST).ToList();
+                return userAttributeSchemas
+                    .Where(x => x.HttpRequestType == HttpRequestTypes.POST)
+                    .ToList();
+
+            case IntegrationMethods.ITSM:
+                var providerUrlId = _appConfig.ItsmConfigurations.ServiceProviderUrls
+                    .FirstOrDefault(x => x.ActionName == ActionNames.CREATE)?.Id;
+                if (providerUrlId == null)
+                    throw new InvalidOperationException("No ServiceProviderUrlId found for CREATE action in ITSM configurations.");
+                
+                return userAttributeSchemas
+                    .Where(x => x.ServiceProviderUrlId == providerUrlId)
+                    .ToList();
+
             default:
                 return userAttributeSchemas.ToList();
         }

--- a/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
@@ -220,9 +220,7 @@ public class CreateUserV4 : ProvisioningBase, ICreateResourceV2
             case IntegrationMethods.ITSM:
                 var providerUrlId = _appConfig.ItsmConfigurations.ServiceProviderUrls
                     .FirstOrDefault(x => x.ActionName == ActionNames.CREATE)?.Id;
-                if (providerUrlId == null)
-                    throw new InvalidOperationException("No ServiceProviderUrlId found for CREATE action in ITSM configurations.");
-                
+             
                 return userAttributeSchemas
                     .Where(x => x.ServiceProviderUrlId == providerUrlId)
                     .ToList();

--- a/KN.KloudIdentity.Mapper/MapperCore/User/DeleteUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/DeleteUserV4.cs
@@ -20,6 +20,8 @@ public class DeleteUserV4(
 )
     : ProvisioningBase(snapshotRepository, outboundPayloadProcessor), IDeleteResourceV2
 {
+    private AppConfig _appConfig = null!;
+
     public async Task DeleteAsync(IResourceIdentifier resourceIdentifier, string appId, string correlationId)
     {
         ArgumentNullException.ThrowIfNull(resourceIdentifier);
@@ -29,15 +31,29 @@ public class DeleteUserV4(
         Log.Information(
             $"[DeleteUserV4] Execution started for user deletion. Identifier: {resourceIdentifier.Identifier}, AppId: {appId}, CorrelationID: {correlationId}");
 
-        var appConfig = await GetAppConfigAsync(appId);
-        if (appConfig.Actions == null || !appConfig.Actions.Any())
+        _appConfig = await GetAppConfigAsync(appId);
+
+        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST)
+            await ExecuteMultistepForRESTAsync(resourceIdentifier.Identifier, appId, correlationId);
+        else
+            await ExecuteGenericUserDeletionLogicAsync(resourceIdentifier.Identifier, appId, correlationId);
+
+        Log.Information(
+            $"User deleted successfully for the id {resourceIdentifier.Identifier}. AppId: {appId}, CorrelationID: {correlationId}");
+        _ = CreateLogAsync(appId, resourceIdentifier.Identifier, correlationId);
+    }
+
+    protected virtual async Task ExecuteMultistepForRESTAsync(string identifier, string appId, string correlationId)
+    {
+        if (_appConfig.Actions == null || !_appConfig.Actions.Any())
             throw new InvalidOperationException("No action steps defined in application configuration.");
-        var integrationOp = integrationBaseFactory.GetIntegration(appConfig.IntegrationMethodOutbound ??
+
+        var integrationOp = integrationBaseFactory.GetIntegration(_appConfig.IntegrationMethodOutbound ??
                                                                   IntegrationMethods.REST, appId) ??
                             throw new NotSupportedException(
-                                $"Integration method {appConfig.IntegrationMethodOutbound} is not supported.");
+                                $"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
 
-        var actionSteps = appConfig.Actions
+        var actionSteps = _appConfig.Actions
             .Where(a => a is { ActionName: ActionNames.DELETE, ActionTarget: ActionTargets.USER })
             .SelectMany(a => a.ActionSteps)
             .OrderBy(s => s.StepOrder)
@@ -50,12 +66,31 @@ public class DeleteUserV4(
         {
             Log.Information("Processing ActionStep {StepOrder} with HttpVerb {HttpVerb}", actionStep.StepOrder,
                 actionStep.HttpVerb);
-            await integrationOp.DeleteAsync(resourceIdentifier.Identifier, appId, appConfig, actionStep, correlationId);
+            await integrationOp.DeleteAsync(identifier, appId, _appConfig, actionStep, correlationId);
         }
+    }
 
-        Log.Information(
-            $"User deleted successfully for the id {resourceIdentifier.Identifier}. AppId: {appId}, CorrelationID: {correlationId}");
-        _ = CreateLogAsync(appId, resourceIdentifier.Identifier, correlationId);
+    protected virtual async Task ExecuteGenericUserDeletionLogicAsync(string identifier, string appId,
+        string correlationId)
+    {
+        var integrationOp = integrationBaseFactory.GetIntegration(_appConfig.IntegrationMethodOutbound ??
+                                                                  IntegrationMethods.REST, appId) ??
+                            throw new NotSupportedException(
+                                $"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
+
+        ValidateRequest(identifier, _appConfig);
+
+        await integrationOp.DeleteAsync(identifier, _appConfig, correlationId);
+    }
+
+    private static void ValidateRequest(string identifier, AppConfig appConfig)
+    {
+        if (appConfig.IntegrationMethodOutbound == IntegrationMethods.AS400 ||
+            appConfig.IntegrationMethodOutbound == IntegrationMethods.SQL)
+            return;
+
+        if (string.IsNullOrWhiteSpace(identifier))
+            throw new ArgumentNullException(nameof(identifier), "Identifier cannot be null or empty");
     }
 
     private async Task CreateLogAsync(string appId, string identifier, string correlationId)

--- a/KN.KloudIdentity.Mapper/MapperCore/User/GetUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/GetUserV4.cs
@@ -16,6 +16,7 @@ public class GetUserV4 : ProvisioningBase, IGetResourceV2
 {
     private readonly IIntegrationBaseFactory _integrationBaseFactory;
     private readonly IKloudIdentityLogger _logger;
+    private AppConfig _appConfig = null!;
 
     public GetUserV4(
         IAppConfigSnapshotRepository snapshotRepository,
@@ -35,16 +36,31 @@ public class GetUserV4 : ProvisioningBase, IGetResourceV2
         Log.Information("Starting GetUserV4 for identifier: {Identifier}, appId: {AppId}", identifier, appId);
 
         // Retrieve full application configuration
-        var appConfig = await GetAppConfigAsync(appId);
+        _appConfig = await GetAppConfigAsync(appId);
 
-        if (appConfig.Actions == null || !appConfig.Actions.Any())
+        var retrievedUser = _appConfig.IntegrationMethodOutbound == IntegrationMethods.REST
+            ? await ExecuteMultistepForRESTAsync(identifier, appId, correlationID)
+            : await ExecuteGenericUserRetrievalLogicAsync(identifier, appId, correlationID);
+
+        Log.Information("Successfully retrieved user with identifier {Identifier} for appId {AppId}", identifier, appId);
+
+        // Create log entry for successful retrieval
+        await CreateLogAsync(appId, identifier, correlationID);
+
+        return retrievedUser;
+    }
+
+    protected virtual async Task<Core2EnterpriseUser> ExecuteMultistepForRESTAsync(string identifier, string appId,
+        string correlationID)
+    {
+        if (_appConfig.Actions == null || !_appConfig.Actions.Any())
             throw new InvalidOperationException("No action steps defined in application configuration.");
 
         // Initialize an empty user object
         Core2EnterpriseUser? retrievedUser = null;
 
         // Process each action step sequentially
-        var actionSteps = appConfig.Actions
+        var actionSteps = _appConfig.Actions
             .Where(action => action.ActionTarget == ActionTargets.USER && action.ActionName == ActionNames.GET)
             .SelectMany(action => action.ActionSteps)
             .OrderBy(step => step.StepOrder);
@@ -56,10 +72,10 @@ public class GetUserV4 : ProvisioningBase, IGetResourceV2
         {
             Log.Information("Processing ActionStep {StepOrder} with HttpVerb {HttpVerb}", actionStep.StepOrder, actionStep.HttpVerb);
 
-            var integrationMethod = _integrationBaseFactory.GetIntegration(appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST, appId)
-                ?? throw new NotSupportedException($"Integration method {appConfig.IntegrationMethodOutbound} is not supported.");
+            var integrationMethod = _integrationBaseFactory.GetIntegration(_appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST, appId)
+                ?? throw new NotSupportedException($"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
 
-            retrievedUser = await integrationMethod.GetAsync(identifier, appConfig, actionStep, correlationID, CancellationToken.None);
+            retrievedUser = await integrationMethod.GetAsync(identifier, _appConfig, actionStep, correlationID, CancellationToken.None);
 
             if (retrievedUser == null)
             {
@@ -74,12 +90,19 @@ public class GetUserV4 : ProvisioningBase, IGetResourceV2
             throw new NotFoundException($"User with identifier {identifier} not found.");
         }
 
-        Log.Information("Successfully retrieved user with identifier {Identifier} for appId {AppId}", identifier, appId);
-
-        // Create log entry for successful retrieval
-        await CreateLogAsync(appId, identifier, correlationID);
-
         return retrievedUser;
+    }
+
+    protected virtual async Task<Core2EnterpriseUser> ExecuteGenericUserRetrievalLogicAsync(string identifier,
+        string appId, string correlationID)
+    {
+        var integrationOp =
+            _integrationBaseFactory.GetIntegration(_appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
+                appId) ??
+            throw new NotSupportedException(
+                $"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
+
+        return await integrationOp.GetAsync(identifier, _appConfig, correlationID);
     }
 
     private async Task CreateLogAsync(string appId, string identifier, string correlationID)

--- a/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs
@@ -1,12 +1,15 @@
 using KN.KI.LogAggregator.Library;
 using KN.KI.LogAggregator.Library.Abstractions;
 using KN.KloudIdentity.Mapper.Common;
+using KN.KloudIdentity.Mapper.Common.Exceptions;
 using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Mapping;
 using KN.KloudIdentity.Mapper.Infrastructure.Persistence.Abstractions;
 using KN.KloudIdentity.Mapper.MapperCore.Outbound;
 using KN.KloudIdentity.Mapper.MapperCore.Outbound.CustomLogic;
 using KN.KloudIdentity.Mapper.Utils;
 using Microsoft.SCIM;
+using Newtonsoft.Json;
 using Serilog;
 
 namespace KN.KloudIdentity.Mapper.MapperCore.User;
@@ -18,6 +21,8 @@ public class ReplaceUserV4(
     IOutboundPayloadProcessor outboundPayloadProcessor)
     : ProvisioningBase(snapshotRepository, outboundPayloadProcessor), IReplaceResourceV2
 {
+    private AppConfig _appConfig = null!;
+
     public virtual async Task ReplaceAsync(Core2EnterpriseUser resource, string appId, string correlationID)
     {
         ArgumentNullException.ThrowIfNull(resource);
@@ -27,27 +32,37 @@ public class ReplaceUserV4(
         Log.Information($"[ReplaceUserV4] Execution started for user replacement. AppId: {appId}, CorrelationID: {correlationID}, Identifier: {resource.Identifier}");
 
         // Step 1: Get app config
-        var appConfig = await GetAppConfigAsync(appId);
+        _appConfig = await GetAppConfigAsync(appId);
+
+        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST)
+            await ExecuteMultistepForRESTAsync(resource, appId, correlationID);
+        else
+            await ExecuteGenericUserReplaceLogicAsync(resource, appId, correlationID);
+
+        _ = CreateLogAsync(_appConfig.AppId, resource.Identifier, correlationID);
+    }
+
+    protected virtual async Task ExecuteMultistepForRESTAsync(Core2EnterpriseUser resource, string appId, string correlationID)
+    {
+        // Resolve integration method operations
+        var integrationOp = integrationBaseFactory.GetIntegration(
+            _appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
+            appId
+        ) ?? throw new NotSupportedException($"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
 
         // Step 2: Find the Replace actions (multi-step)
-        var actionSteps = appConfig.Actions
-            .Where(a => a.ActionName == ActionNames.EDIT && a.ActionTarget == ActionTargets.USER)
+        var actionSteps = _appConfig.Actions?
+            .Where(a => a is { ActionName: ActionNames.EDIT, ActionTarget: ActionTargets.USER })
             .SelectMany(a => a.ActionSteps)
             .OrderBy(s => s.StepOrder)
-            .ToList();
+            .ToList()
+            ?? [];
 
         if (actionSteps.Count == 0)
         {
             throw new InvalidOperationException($"No EDIT actions for USER target found for AppId: {appId}");
         }
 
-        // Step 3: Get integration operator
-        var integrationOp = integrationBaseFactory.GetIntegration(
-            appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
-            appId
-        ) ?? throw new NotSupportedException($"Integration method {appConfig.IntegrationMethodOutbound} is not supported.");
-
-        // Step 4: For each action step, map and send the payload
         foreach (var step in actionSteps)
         {
             Log.Information($"[ReplaceUserV4] Processing ActionStep {step.StepOrder} with HttpVerb {step.HttpVerb}");
@@ -58,21 +73,76 @@ public class ReplaceUserV4(
             var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource);
             Log.Information($"[ReplaceUserV4] Payload mapped and prepared successfully for ActionStep {step.StepOrder}, AppId: {appId}, CorrelationID: {correlationID}");
 
-            var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, appConfig, correlationID);
+            var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, _appConfig, correlationID);
             if (!payloadValidationResult.Item1)
             {
                 Log.Error($"[ReplaceUserV4] Payload validation failed for ActionStep {step.StepOrder}, AppId: {appId}, CorrelationID: {correlationID}. Errors: {string.Join(", ", payloadValidationResult.Item2)}");
-                throw new InvalidOperationException($"Payload validation failed: {string.Join(", ", payloadValidationResult.Item2)}");
+                throw new PayloadValidationException(appId, payloadValidationResult.Item2);
             }
 
+            payload = await ExecuteCustomLogicAsync(payload, _appConfig, correlationID);
+
             // Call the integration method's ReplaceAsync
-            var result = await integrationOp.ReplaceAsync(payload, resource, appConfig.AppId, appConfig, step, correlationID, CancellationToken.None);
-            resource.Identifier = result.Identifier; // Update identifier if changed
+            var result = await integrationOp.ReplaceAsync(payload, resource, _appConfig.AppId, _appConfig, step, correlationID, CancellationToken.None);
+            resource.Identifier = result.Identifier;
 
             Log.Information($"[ReplaceUserV4] Successfully processed ActionStep {step.StepOrder} for user {resource.Identifier}");
         }
+    }
 
-        _ = CreateLogAsync(appConfig.AppId, resource.Identifier, correlationID);
+    protected virtual async Task ExecuteGenericUserReplaceLogicAsync(Core2EnterpriseUser resource, string appId, string correlationID)
+    {
+        var integrationOp = integrationBaseFactory.GetIntegration(
+            _appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
+            appId
+        ) ?? throw new NotSupportedException($"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
+
+        var userAttributes = GetUserAttributes(_appConfig.UserAttributeSchemas, _appConfig.IntegrationMethodOutbound);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource);
+        Log.Information(
+            "[ReplaceUserV4] Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",
+            appId, correlationID, JsonConvert.SerializeObject(payload));
+
+        var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, _appConfig, correlationID);
+        if (!payloadValidationResult.Item1)
+        {
+            Log.Error("[ReplaceUserV4] Payload validation failed. AppId: {AppId}, CorrelationID: {CorrelationID}, Error: {Error}",
+                appId, correlationID, payloadValidationResult.Item2);
+            throw new PayloadValidationException(appId, payloadValidationResult.Item2);
+        }
+
+        payload = await ExecuteCustomLogicAsync(payload, _appConfig, correlationID);
+
+        await integrationOp.ReplaceAsync(payload, resource, _appConfig, correlationID);
+
+        Log.Information(
+            "[ReplaceUserV4] User replaced successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
+            resource.Identifier, appId, correlationID);
+    }
+
+    private IList<AttributeSchema> GetUserAttributes(ICollection<AttributeSchema> userAttributeSchemas,
+        IntegrationMethods? integrationMethodOutbound)
+    {
+        if (userAttributeSchemas == null)
+            return new List<AttributeSchema>();
+
+        switch (integrationMethodOutbound)
+        {
+            case IntegrationMethods.REST:
+            case IntegrationMethods.SQL:
+                return userAttributeSchemas
+                    .Where(x => x.HttpRequestType == HttpRequestTypes.PUT)
+                    .ToList();
+
+            case IntegrationMethods.ITSM:
+                var providerUrlId = _appConfig.ItsmConfigurations.ServiceProviderUrls
+                    .FirstOrDefault(x => x.ActionName == ActionNames.EDIT)?.Id;
+
+                return [.. userAttributeSchemas.Where(x => x.ServiceProviderUrlId == providerUrlId)];
+
+            default:
+                return userAttributeSchemas.ToList();
+        }
     }
 
     private async Task CreateLogAsync(string appId, string identifier, string correlationID)

--- a/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
@@ -1,12 +1,15 @@
 using KN.KI.LogAggregator.Library;
 using KN.KI.LogAggregator.Library.Abstractions;
 using KN.KloudIdentity.Mapper.Common;
+using KN.KloudIdentity.Mapper.Common.Exceptions;
 using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Mapping;
 using KN.KloudIdentity.Mapper.Infrastructure.Persistence.Abstractions;
 using KN.KloudIdentity.Mapper.MapperCore.Outbound;
 using KN.KloudIdentity.Mapper.MapperCore.Outbound.CustomLogic;
 using KN.KloudIdentity.Mapper.Utils;
 using Microsoft.SCIM;
+using Newtonsoft.Json;
 using Serilog;
 
 namespace KN.KloudIdentity.Mapper.MapperCore.User;
@@ -18,20 +21,19 @@ public class UpdateUserV4(
     IIntegrationBaseFactory integrationBaseFactory)
     : ProvisioningBase(snapshotRepository, outboundPayloadProcessor), IUpdateResourceV2
 {
+    private AppConfig _appConfig = null!;
+
     public async Task UpdateAsync(IPatch patch, string appId, string correlationId)
     {
         ArgumentNullException.ThrowIfNull(patch);
         ArgumentException.ThrowIfNullOrWhiteSpace(appId);
         ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
-        
+
         Log.Information($"[UpdateUserV4] Execution started for user update. AppId: {appId}, CorrelationID: {correlationId}");
-        
+
         // Step 1: Get app config
-        var appConfig = await GetAppConfigAsync(appId);
-        var integrationOp = integrationBaseFactory.GetIntegration(
-            appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
-            appId) ?? throw new NotSupportedException($"Integration method {appConfig.IntegrationMethodOutbound} is not supported.");
-        
+        _appConfig = await GetAppConfigAsync(appId);
+
         if (patch.PatchRequest is not PatchRequest2 patchRequest)
         {
             var actualType = patch.PatchRequest?.GetType().FullName ?? "null";
@@ -39,17 +41,32 @@ public class UpdateUserV4(
             throw new NotSupportedException(
                 $"Unsupported patch request type '{actualType}' for argument '{nameof(patch)}'. Expected '{typeof(PatchRequest2).FullName}'.");
         }
-        
+
         Core2EnterpriseUser user = new Core2EnterpriseUser();
         user.Apply(patchRequest);
         user.Identifier = patch.ResourceIdentifier.Identifier;
-        
+
+        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST)
+            await ExecuteMultistepForRESTAsync(user, appId, correlationId);
+        else
+            await ExecuteGenericUserUpdateLogicAsync(user, appId, correlationId);
+
+        _ = CreateLogAsync(_appConfig.AppId, user.Identifier, correlationId);
+    }
+
+    protected virtual async Task ExecuteMultistepForRESTAsync(Core2EnterpriseUser user, string appId, string correlationId)
+    {
+        var integrationOp = integrationBaseFactory.GetIntegration(
+            _appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
+            appId) ?? throw new NotSupportedException($"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
+
         // Step 2: Find the Update actions (multistep)
-        var actionSteps = appConfig.Actions
+        var actionSteps = _appConfig.Actions?
             .Where(a => a is { ActionName: ActionNames.EDIT, ActionTarget: ActionTargets.USER })
             .SelectMany(a => a.ActionSteps)
             .OrderBy(s => s.StepOrder)
-            .ToList();
+            .ToList()
+            ?? [];
 
         if (!actionSteps.Any())
         {
@@ -63,28 +80,88 @@ public class UpdateUserV4(
             Log.Information(
                 "[UpdateUserV4] Payload mapped and prepared successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
                 user.Identifier, appId, correlationId);
-            
-            var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, appConfig, correlationId);
+
+            var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, _appConfig, correlationId);
             if (!payloadValidationResult.Item1)
             {
                 Log.Error($"[UpdateUserV4] Payload validation failed for ActionStep {step.StepOrder}, AppId: {appId}, CorrelationID: {correlationId}. Errors: {string.Join(", ", payloadValidationResult.Item2)}");
-                throw new InvalidOperationException($"Payload validation failed: {string.Join(", ", payloadValidationResult.Item2)}");
+                throw new PayloadValidationException(appId, payloadValidationResult.Item2);
             }
-            
+
             // Execute custom logic
-            payload = await ExecuteCustomLogicAsync(payload, appConfig, correlationId);
+            payload = await ExecuteCustomLogicAsync(payload, _appConfig, correlationId);
 
             // Step 4: Update user
-            await integrationOp.UpdateAsync(payload, user, appId, appConfig, step, correlationId, CancellationToken.None);
-            
+            await integrationOp.UpdateAsync(payload, user, appId, _appConfig, step, correlationId, CancellationToken.None);
+
             Log.Information(
                 "[UpdateUserV4] User updated successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
                 user.Identifier, appId, correlationId);
-            
         }
-        _ = CreateLogAsync(appConfig.AppId, user.Identifier, correlationId);
     }
-    
+
+    protected virtual async Task ExecuteGenericUserUpdateLogicAsync(Core2EnterpriseUser user, string appId, string correlationId)
+    {
+        var integrationOp = integrationBaseFactory.GetIntegration(
+            _appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
+            appId) ?? throw new NotSupportedException($"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
+
+        var userAttributes = GetUserAttributes(_appConfig.UserAttributeSchemas, _appConfig.IntegrationMethodOutbound);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, user);
+        Log.Information(
+            "[UpdateUserV4] Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",
+            appId, correlationId, JsonConvert.SerializeObject(payload));
+
+        var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, _appConfig, correlationId);
+        if (!payloadValidationResult.Item1)
+        {
+            Log.Error("[UpdateUserV4] Payload validation failed. AppId: {AppId}, CorrelationID: {CorrelationID}, Error: {Error}",
+                appId, correlationId, payloadValidationResult.Item2);
+            throw new PayloadValidationException(appId, payloadValidationResult.Item2);
+        }
+
+        payload = await ExecuteCustomLogicAsync(payload, _appConfig, correlationId);
+
+        await integrationOp.UpdateAsync(payload, user, _appConfig, correlationId);
+
+        Log.Information(
+            "[UpdateUserV4] User updated successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
+            user.Identifier, appId, correlationId);
+    }
+
+    private IList<AttributeSchema> GetUserAttributes(ICollection<AttributeSchema> userAttributeSchemas,
+        IntegrationMethods? integrationMethodOutbound)
+    {
+        if (userAttributeSchemas == null)
+            return new List<AttributeSchema>();
+
+        switch (integrationMethodOutbound)
+        {
+            case IntegrationMethods.REST:
+            case IntegrationMethods.SQL:
+                var patchAttrs = userAttributeSchemas
+                    .Where(x => x.HttpRequestType == HttpRequestTypes.PATCH)
+                    .ToList();
+
+                return patchAttrs.Count != 0
+                    ? patchAttrs
+                    : userAttributeSchemas.Where(x => x.HttpRequestType == HttpRequestTypes.PUT).ToList();
+
+            case IntegrationMethods.ITSM:
+                var providerUrlId = _appConfig.ItsmConfigurations.ServiceProviderUrls
+                    .FirstOrDefault(x => x.ActionName == ActionNames.EDIT)?.Id;
+                if (providerUrlId == null)
+                    throw new InvalidOperationException("No ServiceProviderUrlId found for EDIT action in ITSM configurations.");
+
+                return userAttributeSchemas
+                    .Where(x => x.ServiceProviderUrlId == providerUrlId)
+                    .ToList();
+
+            default:
+                return userAttributeSchemas.ToList();
+        }
+    }
+
     private async Task CreateLogAsync(string appId, string identifier, string correlationId)
     {
         var logEntity = new CreateLogEntity(

--- a/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
@@ -150,9 +150,7 @@ public class UpdateUserV4(
             case IntegrationMethods.ITSM:
                 var providerUrlId = _appConfig.ItsmConfigurations.ServiceProviderUrls
                     .FirstOrDefault(x => x.ActionName == ActionNames.EDIT)?.Id;
-                if (providerUrlId == null)
-                    throw new InvalidOperationException("No ServiceProviderUrlId found for EDIT action in ITSM configurations.");
-
+                
                 return userAttributeSchemas
                     .Where(x => x.ServiceProviderUrlId == providerUrlId)
                     .ToList();

--- a/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
+++ b/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
@@ -65,7 +65,7 @@ public static class ServiceExtension
 
         services.AddScoped<IIntegrationBase, RestIntegrationManageEngine>();
         services.AddScoped<IIntegrationBaseV2, RESTIntegrationV4>();
-        services.AddScoped<IIntegrationBaseV2, DisconnectedIntegration>();
+        services.AddScoped<IIntegrationBaseV2, ITSMIntegration>();
 
         services.AddScoped<IIntegrationBase, RESTIntegration>();
         services.AddScoped<IIntegrationBase, LinuxIntegration>();

--- a/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
+++ b/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
@@ -65,6 +65,7 @@ public static class ServiceExtension
 
         services.AddScoped<IIntegrationBase, RestIntegrationManageEngine>();
         services.AddScoped<IIntegrationBaseV2, RESTIntegrationV4>();
+        services.AddScoped<IIntegrationBaseV2, DisconnectedIntegration>();
 
         services.AddScoped<IIntegrationBase, RESTIntegration>();
         services.AddScoped<IIntegrationBase, LinuxIntegration>();

--- a/KN.KloudIdentity.MapperTests/MapperCore/User/GetUserV4Tests.cs
+++ b/KN.KloudIdentity.MapperTests/MapperCore/User/GetUserV4Tests.cs
@@ -121,7 +121,8 @@ public class GetUserV4Tests
             {
                 AppId = appId,
                 Actions = new List<Mapper.Domain.Application.Action>(), // No actions defined
-                AuthenticationDetails = default!
+                AuthenticationDetails = default!,
+                IntegrationMethodOutbound = IntegrationMethods.REST
             });
 
         // Act & Assert
@@ -153,7 +154,8 @@ public class GetUserV4Tests
                         ActionSteps = new List<ActionStep>()
                     }
                 },
-                AuthenticationDetails = default!
+                AuthenticationDetails = default!,
+                IntegrationMethodOutbound = IntegrationMethods.REST
             });
 
         // Act & Assert

--- a/KN.KloudIdentity.MapperTests/MapperCore/User/ReplaceUserV4Tests.cs
+++ b/KN.KloudIdentity.MapperTests/MapperCore/User/ReplaceUserV4Tests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using KN.KI.LogAggregator.Library;
 using KN.KI.LogAggregator.Library.Abstractions;
 using KN.KloudIdentity.Mapper;
+using KN.KloudIdentity.Mapper.Common.Exceptions;
 using KN.KloudIdentity.Mapper.Domain.Application;
 using KN.KloudIdentity.Mapper.Domain.Mapping;
 using KN.KloudIdentity.Mapper.Infrastructure.ExternalAPIs.Abstractions;
@@ -57,6 +58,8 @@ public class ReplaceUserV4Tests
         };
         var sut = CreateSut(appConfig);
         var user = new Core2EnterpriseUser { Identifier = "user1" };
+        _integrationBaseFactoryMock.Setup(f => f.GetIntegration(It.IsAny<IntegrationMethods>(), It.IsAny<string>()))
+            .Returns(_integrationBaseMock.Object);
 
         // Act & Assert
         await Xunit.Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -93,7 +96,7 @@ public class ReplaceUserV4Tests
     }
 
     [Fact]
-    public async Task ReplaceAsync_ThrowsInvalidOperationException_WhenPayloadValidationFails()
+    public async Task ReplaceAsync_ThrowsPayloadValidationException_WhenPayloadValidationFails()
     {
         // Arrange
         var actionStep = new ActionStep { StepOrder = 1, UserAttributeSchemas = new List<AttributeSchema>() };
@@ -132,7 +135,7 @@ public class ReplaceUserV4Tests
         var user = new Core2EnterpriseUser { Identifier = "user1" };
 
         // Act & Assert
-        var ex = await Xunit.Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await Xunit.Assert.ThrowsAsync<PayloadValidationException>(() =>
             sut.ReplaceAsync(user, "app1", "corr1"));
         Assert.Contains("Payload validation failed", ex.Message);
     }
@@ -284,6 +287,8 @@ public class ReplaceUserV4Tests
         };
         var sut = CreateSut(appConfig);
         var user = new Core2EnterpriseUser { Identifier = "user1" };
+        _integrationBaseFactoryMock.Setup(f => f.GetIntegration(It.IsAny<IntegrationMethods>(), It.IsAny<string>()))
+            .Returns(_integrationBaseMock.Object);
 
         // Act & Assert
         var ex = await Xunit.Assert.ThrowsAsync<InvalidOperationException>(() => sut.ReplaceAsync(user, "app1", "corr1"));

--- a/KN.KloudIdentity.MapperTests/MapperCore/User/UpdateUserV4Tests.cs
+++ b/KN.KloudIdentity.MapperTests/MapperCore/User/UpdateUserV4Tests.cs
@@ -1,5 +1,6 @@
 using KN.KI.LogAggregator.Library;
 using KN.KI.LogAggregator.Library.Abstractions;
+using KN.KloudIdentity.Mapper.Common.Exceptions;
 using KN.KloudIdentity.Mapper.Domain.Application;
 using KN.KloudIdentity.Mapper.Domain.Mapping;
 using KN.KloudIdentity.Mapper.Infrastructure.Persistence.Abstractions;
@@ -119,7 +120,7 @@ public class UpdateUserV4Tests
     }
 
     [Fact]
-    public async Task UpdateAsync_ThrowsInvalidOperationException_WhenPayloadValidationFails()
+    public async Task UpdateAsync_ThrowsPayloadValidationException_WhenPayloadValidationFails()
     {
         // Arrange
         var actionStep = new ActionStep { StepOrder = 1, UserAttributeSchemas = new List<AttributeSchema>() };
@@ -176,7 +177,7 @@ public class UpdateUserV4Tests
         };
 
         // Act & Assert
-        var ex = await Xunit.Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await Xunit.Assert.ThrowsAsync<PayloadValidationException>(() =>
             sut.UpdateAsync(user, "app1", "corr1"));
         Assert.Contains("Payload validation failed", ex.Message);
     }

--- a/Microsoft.SCIM.WebHostSample/appsettings.json
+++ b/Microsoft.SCIM.WebHostSample/appsettings.json
@@ -30,7 +30,8 @@
       "REST": "RESTIntegrationV4",
       "AS400": "AS400Integration",
       "Linux": "LinuxIntegration",
-      "SQL": "SQLIntegration"
+      "SQL": "SQLIntegration",
+      "Disconnected": "DisconnectedIntegration"
     }
   }
 }

--- a/Microsoft.SCIM.WebHostSample/appsettings.json
+++ b/Microsoft.SCIM.WebHostSample/appsettings.json
@@ -31,7 +31,7 @@
       "AS400": "AS400Integration",
       "Linux": "LinuxIntegration",
       "SQL": "SQLIntegration",
-      "Disconnected": "DisconnectedIntegration"
+      "ITSM": "ITSMIntegration"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Added a disconnected/ITSM outbound integration path for V4 user provisioning.
- Introduced `DisconnectedIntegration` to support create, get, update, replace, and delete operations through the metaverse service.
- Added `IMetaverseIntegrationClient` and `MetaverseIntegrationClient` for MassTransit-based metaverse requests.
- Extended app configuration/domain models with tenant ID, ITSM settings, service provider URLs, and service-provider-specific attribute mapping.
- Updated V4 user operations to support both REST action-step flows and generic non-REST integration flows.
- Registered disconnected integration and metaverse client dependencies.
- Updated unit tests to assert `PayloadValidationException` and REST-specific action-step behavior.