### PR TITLE
Enhance SOAP integration for user creation, replacement, and updates

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
@@ -48,7 +48,7 @@ public class CreateUserV4(
         }
 
         // Step 3: Handle multistep API calls if applicable
-        resource = _appConfig.IntegrationMethodOutbound == IntegrationMethods.REST
+        resource = (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP)
             ? await ExecuteMultistepForRESTAsync(resource, appId, correlationID)
             : await ExecuteGenericUserCreationLogicAsync(resource, appId, correlationID);
 
@@ -72,7 +72,13 @@ public class CreateUserV4(
         {
             // Attribute mapping
             var userAttributes = step.UserAttributeSchemas?.ToList() ?? [];
-            var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig);
+
+            // For SOAP, we need to get the specific mapping config for the Create action. For other integration methods, we can pass the whole appConfig.
+            var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Create);
+
+            var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
+            var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, config);            
+            
             Log.Information(
                 "Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Step: {Step}, Payload: {Payload}",
                 appId, correlationID, step.StepOrder, JsonConvert.SerializeObject(payload));
@@ -203,6 +209,7 @@ public class CreateUserV4(
         {
             case IntegrationMethods.REST:
             case IntegrationMethods.SQL:
+            case IntegrationMethods.SOAP:
                 return userAttributeSchemas
                     .Where(x => x.HttpRequestType == HttpRequestTypes.POST)
                     .ToList();

--- a/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs
@@ -36,7 +36,7 @@ public class ReplaceUserV4(
         // Step 1: Get app config
         _appConfig = await GetAppConfigForTenantAsync(tenantContext.TenantId, appId, CancellationToken.None);
 
-        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST)
+        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP)
             await ExecuteMultistepForRESTAsync(resource, appId, correlationID);
         else
             await ExecuteGenericUserReplaceLogicAsync(resource, appId, correlationID);
@@ -73,8 +73,11 @@ public class ReplaceUserV4(
 
             // Map the user resource to the outbound payload
             var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
+
+            var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
+
+            var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource, config);
             
-            var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource, mappingConfig);
             Log.Information($"[ReplaceUserV4] Payload mapped and prepared successfully for ActionStep {step.StepOrder}, AppId: {appId}, CorrelationID: {correlationID}");
 
             var payloadValidationResult = await integrationOp.ValidatePayloadAsync(payload, _appConfig, correlationID);

--- a/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
@@ -48,7 +48,7 @@ public class UpdateUserV4(
         user.Apply(patchRequest);
         user.Identifier = patch.ResourceIdentifier.Identifier;
 
-        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST)
+        if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.REST || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP)
             await ExecuteMultistepForRESTAsync(user, appId, correlationId);
         else
             await ExecuteGenericUserUpdateLogicAsync(user, appId, correlationId);
@@ -78,8 +78,12 @@ public class UpdateUserV4(
         foreach (var step in actionSteps)
         {
             var attributes = step.UserAttributeSchemas?.ToList() ?? [];
-            
-            var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, user);
+
+            // For SOAP, we need to get the specific mapping config for the Update action. For other integration methods, we can pass the whole appConfig.
+            var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
+            var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
+
+            var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, user, config);
             Log.Information(
                 "[UpdateUserV4] Payload mapped and prepared successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
                 user.Identifier, appId, correlationId);


### PR DESCRIPTION
This pull request adds support for the `SOAP` integration method in the user creation, replacement, and update flows. It ensures that the correct mapping configuration is used for SOAP actions and that SOAP is handled consistently alongside REST throughout the codebase.

**Integration method support:**
* Added `SOAP` as a supported integration method for multi-step user creation, replacement, and update logic in `CreateUserV4`, `ReplaceUserV4`, and `UpdateUserV4` by updating the conditional checks to include `IntegrationMethods.SOAP`. [[1]](diffhunk://#diff-e54e400d2cb20bcf63ed7ac0e55e2b630d20e845b6603a5f6b0d60ac7f508b75L51-R51) [[2]](diffhunk://#diff-26717c45ff236dbcc5339e8c638c1be7d5b4407da21dfbd13f4d34c994d1bd6bL39-R39) [[3]](diffhunk://#diff-d67ab008287a75f3714e6377b2ed4763803e10046c7fc0a7bff400cb19997597L51-R51)

**SOAP-specific mapping configuration:**
* Updated the payload mapping logic to use the SOAP action-specific mapping configuration (`GetMappingConfigForSoapAction`) when the outbound integration method is `SOAP`, ensuring the correct config is passed to `MapAndPreparePayloadAsync` in all relevant methods. [[1]](diffhunk://#diff-e54e400d2cb20bcf63ed7ac0e55e2b630d20e845b6603a5f6b0d60ac7f508b75L75-R81) [[2]](diffhunk://#diff-26717c45ff236dbcc5339e8c638c1be7d5b4407da21dfbd13f4d34c994d1bd6bL77-R80) [[3]](diffhunk://#diff-d67ab008287a75f3714e6377b2ed4763803e10046c7fc0a7bff400cb19997597L82-R86)

**Attribute schema filtering:**
* Modified the `GetUserAttributes` method to include `SOAP` in the list of integration methods that filter attributes by `HttpRequestType == POST`.