### PR TITLE
Refactor SOAP authentication handling and migrate options

### DIFF
--- a/.github/prompts/plan-modify-appconfig-soap-authentication.md
+++ b/.github/prompts/plan-modify-appconfig-soap-authentication.md
@@ -1,0 +1,147 @@
+# Plan: Move SOAPAuthenticationOptions from AppConfig to AuthenticationFlow Steps
+
+## Background
+
+Currently `SOAPAuthenticationOptions` is a typed property on `AppConfig` (`AppConfig.SOAPAuthenticationOptions`).
+The goal is to move it into `AuthenticationFlow` steps so that SOAP authentication credentials are passed
+through `AuthenticationFlowStep.AuthenticationDetails` (dynamic type), consistent with how other
+authentication methods are handled via the flow.
+
+For SOAP integrations, `AppConfig.AuthenticationDetails` will be **null** — all authentication
+configuration will arrive exclusively through `AuthenticationFlow.Steps[*].AuthenticationDetails`.
+
+---
+
+## Files Affected
+
+| File | Change Type |
+|---|---|
+| `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs` | Primary logic change |
+| `KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs` | Mark property obsolete |
+| `KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs` | New test cases |
+
+---
+
+## Step 1 — Add a Direct-Deserialization Helper
+
+**File:** `SOAPIntegration.cs`
+
+Add a new private static helper method:
+
+```csharp
+private static bool TryDeserializeSoapAuthDirectly(JsonElement root, out SOAPAuthenticationOptions? options)
+```
+
+- Calls `root.Deserialize<SOAPAuthenticationOptions>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true })`
+- Accepts the result only if at least one section is non-null (`Transport`, `WsSecurity`, or `TokenPlacement`)
+- Returns `true` and populates `options` on success; `false` otherwise
+
+**Why:** The existing `TryReadSoapAuthOptions` looks for a named property key inside a wrapper object.
+A flow step's `AuthenticationDetails` may be the `SOAPAuthenticationOptions` object directly (no wrapper),
+so a direct deserialization path is required.
+
+---
+
+## Step 2 — Add a Shared Extraction Helper for `dynamic` Auth Details
+
+**File:** `SOAPIntegration.cs`
+
+Add a new private static helper method:
+
+```csharp
+private static bool TryExtractSoapAuthFromDetails(dynamic authDetails, out SOAPAuthenticationOptions? options)
+```
+
+Logic (in order):
+1. Serialize `authDetails` to a JSON string
+2. Parse as `JsonDocument`
+3. Attempt **direct** deserialization via Step 1 helper → return if valid
+4. Attempt **nested key** lookup via existing `TryReadSoapAuthOptions` with all known key variants:
+   `"SOAPAuthenticationOptions"`, `"SoapAuthenticationOptions"`, `"soapAuthenticationOptions"`, `"soapAuthOptions"`
+5. Return `true` and populate `options` on first success; `false` if all attempts fail
+
+---
+
+## Step 3 — Rewrite `ResolveSoapAuthenticationOptions`
+
+**File:** `SOAPIntegration.cs`
+
+**Remove** the existing `appConfig.AuthenticationDetails` fallback block entirely.
+It will always be null for SOAP integrations and is no longer part of the resolution chain.
+
+**New resolution order:**
+
+| Priority | Source | Notes |
+|---|---|---|
+| 1 | `AuthenticationFlow.Steps[*].AuthenticationDetails` | Primary — walk steps in `StepOrder` ascending, return first match |
+| 2 | `AppConfig.SOAPAuthenticationOptions` | Backward compat — existing typed property, used until fully migrated |
+
+Implementation for priority-1:
+
+```csharp
+var steps = appConfig.AuthenticationFlow?.Steps;
+if (steps != null)
+{
+    foreach (var step in steps.OrderBy(s => s.StepOrder))
+    {
+        if (step.AuthenticationDetails == null) continue;
+        if (TryExtractSoapAuthFromDetails(step.AuthenticationDetails, out var stepOptions))
+            return stepOptions;
+    }
+}
+```
+
+---
+
+## Step 4 — Mark `AppConfig.SOAPAuthenticationOptions` as Obsolete
+
+**File:** `AppConfig.cs`
+
+```csharp
+[Obsolete("Configure SOAPAuthenticationOptions via AuthenticationFlow step AuthenticationDetails instead.")]
+public SOAPAuthenticationOptions? SOAPAuthenticationOptions { get; set; }
+```
+
+Do **not** remove the property yet. Existing stored configurations that still carry the typed property
+continue to work via the priority-2 fallback path. Removal is a follow-up task once all consumers
+have been migrated to flow steps.
+
+---
+
+## Step 5 — Update Tests
+
+**File:** `SOAPIntegrationUnitTests.cs`
+
+Existing tests pass `SOAPAuthenticationOptions` via `AppConfig.SOAPAuthenticationOptions` directly.
+They continue to pass unchanged via the priority-2 fallback path — no modification required.
+
+Add three new test cases to cover the priority-1 path:
+
+### Test 1 — Direct shape
+`SOAPAuthOptions_ResolvedFromFlowStep_DirectShape`
+- `AuthenticationDetails` is a `SOAPAuthenticationOptions` JSON object at the root (no wrapper key)
+- Asserts the correct `SOAPAuthenticationOptions` is resolved
+
+### Test 2 — Nested key shape
+`SOAPAuthOptions_ResolvedFromFlowStep_NestedKeyShape`
+- `AuthenticationDetails` wraps the options under `"SOAPAuthenticationOptions"` key
+- Asserts the correct `SOAPAuthenticationOptions` is resolved
+
+### Test 3 — Flow step takes priority
+`SOAPAuthOptions_FlowStepTakesPriorityOver_AppConfigProperty`
+- Both `AuthenticationFlow.Steps[0].AuthenticationDetails` and `AppConfig.SOAPAuthenticationOptions` are set with different values
+- Asserts that the flow step value wins (priority-1)
+
+---
+
+## What Does NOT Change
+
+| Component | Reason |
+|---|---|
+| `SoapAuthContext.AuthOptions` | Already `SOAPAuthenticationOptions?`; how the value is resolved is transparent to the appliers |
+| All `ISoapAuthApplier` implementations | Read from `SoapAuthContext.AuthOptions`; source of that value is irrelevant |
+| `AuthContextV2` / `GetTokenListAsync` | No enum changes in this step; no new strategies; untouched |
+| `AuthenticationFlowStep` model | `AuthenticationDetails` is already `dynamic`; no schema change needed |
+| DI registrations | No new types registered |
+
+---

--- a/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
@@ -46,5 +46,7 @@ public record AppConfig
         }
     }
     public ICollection<SOAPTemplate>? SOAPTemplates { get; set; }
+
+    [Obsolete("Configure SOAPAuthenticationOptions via AuthenticationFlow step AuthenticationDetails instead.")]
     public SOAPAuthenticationOptions? SOAPAuthenticationOptions { get; set; }
 }

--- a/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
@@ -46,7 +46,4 @@ public record AppConfig
         }
     }
     public ICollection<SOAPTemplate>? SOAPTemplates { get; set; }
-
-    [Obsolete("Configure SOAPAuthenticationOptions via AuthenticationFlow step AuthenticationDetails instead.")]
-    public SOAPAuthenticationOptions? SOAPAuthenticationOptions { get; set; }
 }

--- a/KN.KloudIdentity.Mapper.Domain/Application/SOAPAuthenticationOptions.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/SOAPAuthenticationOptions.cs
@@ -1,3 +1,5 @@
+using KN.KloudIdentity.Mapper.Domain.Authentication;
+
 namespace KN.KloudIdentity.Mapper.Domain.Application;
 
 public record SOAPAuthenticationOptions
@@ -15,6 +17,8 @@ public record BasicOrNtlmSoapAuthOptions
     public string? Username { get; init; }
     public string? Password { get; init; }
     public string? Domain { get; init; }
+    public string? KeyVaultReference { get; init; }
+    public EncryptedData? EncryptedData { get; init; }
 }
 
 public record WsSecuritySoapAuthOptions
@@ -23,6 +27,8 @@ public record WsSecuritySoapAuthOptions
     public string? Username { get; init; }
     public string? Password { get; init; }
     public bool IncludeTimestamp { get; init; }
+    public string? KeyVaultReference { get; init; }
+    public EncryptedData? EncryptedData { get; init; }
 }
 
 public record SoapTokenPlacementOptions

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -455,14 +455,7 @@ namespace KN.KloudIdentity.Mapper.MapperCore
                     if (TryExtractSoapAuthFromDetails(step.AuthenticationDetails, out SOAPAuthenticationOptions? stepOptions))
                         return stepOptions;
                 }
-            }
-
-            // Priority 2: Typed property on AppConfig — backward compat for existing configurations
-            // that have not yet been migrated to AuthenticationFlow steps.
-#pragma warning disable CS0618
-            if (appConfig.SOAPAuthenticationOptions != null)
-                return appConfig.SOAPAuthenticationOptions;
-#pragma warning restore CS0618
+            }         
 
             return null;
         }

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -442,10 +442,7 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         }
 
         private static SOAPAuthenticationOptions? ResolveSoapAuthenticationOptions(AppConfig appConfig)
-        {
-            // Priority 1: AuthenticationFlow steps — walk in StepOrder, first match wins.
-            // For SOAP integrations AuthenticationDetails on AppConfig will be null;
-            // all auth configuration is passed through flow step AuthenticationDetails.
+        {         
             var steps = appConfig.AuthenticationFlow?.Steps;
             if (steps != null)
             {
@@ -455,7 +452,7 @@ namespace KN.KloudIdentity.Mapper.MapperCore
                     if (TryExtractSoapAuthFromDetails(step.AuthenticationDetails, out SOAPAuthenticationOptions? stepOptions))
                         return stepOptions;
                 }
-            }         
+            }          
 
             return null;
         }

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -26,6 +26,8 @@ namespace KN.KloudIdentity.Mapper.MapperCore
     /// </summary>
     public class SOAPIntegration : IIntegrationBaseV2
     {
+        private static readonly JsonSerializerOptions CaseInsensitiveJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
         private readonly IAuthContext _authContext;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IConfiguration _configuration;
@@ -58,8 +60,9 @@ namespace KN.KloudIdentity.Mapper.MapperCore
 
         public virtual async Task<dynamic> GetAuthenticationAsync(AppConfig config, SCIMDirections direction = SCIMDirections.Outbound, CancellationToken cancellationToken = default, params dynamic[] args)
         {
-            // Reuse REST logic for token retrieval if needed
-            return await _authContext.GetTokenAsync(config, direction);
+            Log.Information($"Getting authentication token for direction: {direction} for app: {config.AppId}");
+
+            return await _authContext.GetTokenListAsync(config, direction);
         }
 
         // Overload that matches the interface (does not require AppConfig)
@@ -360,16 +363,33 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             string? token = null;
             if (ShouldResolveToken(appConfig, soapAuthOptions, direction))
             {
-                token = await GetAuthenticationAsync(appConfig, direction, cancellationToken);
-            }
+                var tokens = await GetAuthenticationAsync(appConfig, direction, cancellationToken) as Dictionary<int, string>;
+                if (tokens != null && !isNtlmEnabled)
+                {
+                    var steps = appConfig.AuthenticationFlow?.Steps;
+                    foreach (var authToken in tokens)
+                    {
+                        var step = steps?.FirstOrDefault(s => s.StepOrder == authToken.Key);
+                        var authMethod = step?.AuthenticationMethod
+                            ?? (direction == SCIMDirections.Inbound
+                                ? appConfig.AuthenticationMethodInbound
+                                : appConfig.AuthenticationMethodOutbound);
+                        var authDetails = step?.AuthenticationDetails != null
+                            ? NormalizeAuthenticationDetails(step.AuthenticationDetails)
+                            : NormalizeAuthenticationDetails(appConfig.AuthenticationDetails);
 
-            if (!isNtlmEnabled && !string.IsNullOrWhiteSpace(token) && appConfig.AuthenticationMethodOutbound != AuthenticationMethods.None)
-            {
-                Utils.HttpClientExtensions.SetAuthenticationHeaders(
-                   client,
-                   appConfig.AuthenticationMethodOutbound,
-                   NormalizeAuthenticationDetails(appConfig.AuthenticationDetails),
-                   token);
+                        if (authMethod != AuthenticationMethods.None)
+                        {
+                            Utils.HttpClientExtensions.SetAuthenticationHeaders(
+                                client, 
+                                authMethod, 
+                                authDetails, 
+                                authToken.Value
+                            );
+                        }
+                    }
+                }
+                token = tokens?.Values.FirstOrDefault();
             }
 
             var customHttpClient = _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == appConfig.AppId);
@@ -423,46 +443,26 @@ namespace KN.KloudIdentity.Mapper.MapperCore
 
         private static SOAPAuthenticationOptions? ResolveSoapAuthenticationOptions(AppConfig appConfig)
         {
-            if (appConfig.SOAPAuthenticationOptions != null)
+            // Priority 1: AuthenticationFlow steps — walk in StepOrder, first match wins.
+            // For SOAP integrations AuthenticationDetails on AppConfig will be null;
+            // all auth configuration is passed through flow step AuthenticationDetails.
+            var steps = appConfig.AuthenticationFlow?.Steps;
+            if (steps != null)
             {
-                return appConfig.SOAPAuthenticationOptions;
-            }
-
-            if (appConfig.AuthenticationDetails == null)
-            {
-                return null;
-            }
-
-            try
-            {
-                var authDetailsJson = JsonSerializer.Serialize(appConfig.AuthenticationDetails);
-                using var document = JsonDocument.Parse(authDetailsJson);
-                var root = document.RootElement;
-                SOAPAuthenticationOptions? options;
-
-                if (TryReadSoapAuthOptions(root, "SOAPAuthenticationOptions", out options)
-                    || TryReadSoapAuthOptions(root, "SoapAuthenticationOptions", out options)
-                    || TryReadSoapAuthOptions(root, "soapAuthenticationOptions", out options)
-                    || TryReadSoapAuthOptions(root, "soapAuthOptions", out options))
+                foreach (var step in steps.OrderBy(s => s.StepOrder))
                 {
-                    return options;
+                    if (step.AuthenticationDetails == null) continue;
+                    if (TryExtractSoapAuthFromDetails(step.AuthenticationDetails, out SOAPAuthenticationOptions? stepOptions))
+                        return stepOptions;
                 }
             }
-            catch (JsonException ex)
-            {
-                Log.Error(ex, "Failed to parse SOAP authentication options from AuthenticationDetails. AppId: {AppId}", appConfig.AppId);
-                return null;
-            }
-            catch (InvalidOperationException ex)
-            {
-                Log.Error(ex, "Failed to parse SOAP authentication options from AuthenticationDetails. AppId: {AppId}", appConfig.AppId);
-                return null;
-            }
-            catch
-            {
-                Log.Error("Failed to parse SOAP authentication options from AuthenticationDetails due to an unexpected error. AppId: {AppId}", appConfig.AppId);
-                return null;
-            }
+
+            // Priority 2: Typed property on AppConfig — backward compat for existing configurations
+            // that have not yet been migrated to AuthenticationFlow steps.
+#pragma warning disable CS0618
+            if (appConfig.SOAPAuthenticationOptions != null)
+                return appConfig.SOAPAuthenticationOptions;
+#pragma warning restore CS0618
 
             return null;
         }
@@ -475,12 +475,53 @@ namespace KN.KloudIdentity.Mapper.MapperCore
                 return false;
             }
 
-            options = value.Deserialize<SOAPAuthenticationOptions>(new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
+            options = value.Deserialize<SOAPAuthenticationOptions>(CaseInsensitiveJsonOptions);
 
             return options != null;
+        }
+
+        private static bool TryDeserializeSoapAuthDirectly(JsonElement root, out SOAPAuthenticationOptions? options)
+        {
+            options = root.Deserialize<SOAPAuthenticationOptions>(CaseInsensitiveJsonOptions);
+
+            if (options == null)
+                return false;
+
+            // Only accept if at least one section is populated — prevents false positives
+            // when unrelated auth details happen to deserialize without error.
+            return options.Transport != null
+                || options.WsSecurity != null
+                || options.TokenPlacement != null;
+        }
+
+        private static bool TryExtractSoapAuthFromDetails(dynamic authDetails, out SOAPAuthenticationOptions? options)
+        {
+            options = null;
+            try
+            {
+                var json = JsonSerializer.Serialize(authDetails);
+                using var document = JsonDocument.Parse(json);
+                var root = document.RootElement;
+
+                if (TryDeserializeSoapAuthDirectly(root, out options))
+                    return true;
+
+                if (TryReadSoapAuthOptions(root, "SOAPAuthenticationOptions", out options)
+                    || TryReadSoapAuthOptions(root, "SoapAuthenticationOptions", out options)
+                    || TryReadSoapAuthOptions(root, "soapAuthenticationOptions", out options)
+                    || TryReadSoapAuthOptions(root, "soapAuthOptions", out options))
+                    return true;
+            }
+            catch (JsonException ex)
+            {
+                Log.Error(ex, "Failed to extract SOAPAuthenticationOptions from AuthenticationDetails.");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Log.Error(ex, "Failed to extract SOAPAuthenticationOptions from AuthenticationDetails.");
+            }
+
+            return false;
         }
 
         protected static dynamic NormalizeAuthenticationDetails(dynamic authenticationDetails)

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
@@ -493,6 +493,156 @@ public class SOAPIntegrationUnitTests
         Assert.IsType<global::KN.KloudIdentity.Mapper.MapperCore.SOAPIntegration>(resolved);
     }
 
+    #region SOAPAuthenticationOptions resolution from AuthenticationFlow steps
+
+    [Fact]
+    public async Task SOAPAuthOptions_ResolvedFromFlowStep_DirectShape_AddsWsseHeaderToPayload()
+    {
+        // AuthenticationDetails is a SOAPAuthenticationOptions object directly (no wrapper key).
+        var handler = new TestHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                      <soap:Body><CreateUserResponse><Identifier>U-DS-1</Identifier></CreateUserResponse></soap:Body>
+                    </soap:Envelope>
+                    """, Encoding.UTF8, "text/xml")
+            });
+
+        var sut = CreateSut(handler);
+        var flow = new AuthenticationFlow
+        {
+            AppId = "soap-app",
+            Name = "SOAP Direct Shape Flow",
+            Steps = [CreateSoapFlowStep(new SOAPAuthenticationOptions
+            {
+                WsSecurity = new WsSecuritySoapAuthOptions
+                {
+                    Enabled = true,
+                    Username = "flow-direct-user",
+                    Password = "flow-direct-pass"
+                }
+            })]
+        };
+
+        var appConfig = CreateAppConfig(authenticationFlow: flow);
+
+        const string payload = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+              <soap:Body><CreateUser /></soap:Body>
+            </soap:Envelope>
+            """;
+
+        await sut.ProvisionAsync(payload, appConfig, "corr-flow-direct");
+
+        Assert.Contains("wsse:Security", handler.LastRequestBody);
+        Assert.Contains("flow-direct-user", handler.LastRequestBody);
+    }
+
+    [Fact]
+    public async Task SOAPAuthOptions_ResolvedFromFlowStep_NestedKeyShape_AddsWsseHeaderToPayload()
+    {
+        // AuthenticationDetails wraps SOAPAuthenticationOptions under the "SOAPAuthenticationOptions" key.
+        var handler = new TestHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                      <soap:Body><CreateUserResponse><Identifier>U-NK-1</Identifier></CreateUserResponse></soap:Body>
+                    </soap:Envelope>
+                    """, Encoding.UTF8, "text/xml")
+            });
+
+        var sut = CreateSut(handler);
+        var flow = new AuthenticationFlow
+        {
+            AppId = "soap-app",
+            Name = "SOAP Nested Key Flow",
+            Steps = [CreateSoapFlowStep(new
+            {
+                SOAPAuthenticationOptions = new SOAPAuthenticationOptions
+                {
+                    WsSecurity = new WsSecuritySoapAuthOptions
+                    {
+                        Enabled = true,
+                        Username = "flow-nested-user",
+                        Password = "flow-nested-pass"
+                    }
+                }
+            })]
+        };
+
+        var appConfig = CreateAppConfig(authenticationFlow: flow);
+
+        const string payload = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+              <soap:Body><CreateUser /></soap:Body>
+            </soap:Envelope>
+            """;
+
+        await sut.ProvisionAsync(payload, appConfig, "corr-flow-nested");
+
+        Assert.Contains("wsse:Security", handler.LastRequestBody);
+        Assert.Contains("flow-nested-user", handler.LastRequestBody);
+    }
+
+    [Fact]
+    public async Task SOAPAuthOptions_FlowStepTakesPriorityOver_AppConfigProperty()
+    {
+        // Both flow step and AppConfig.SOAPAuthenticationOptions are set with different usernames.
+        // Asserts the flow step value (priority-1) wins over the typed property (priority-2).
+        var handler = new TestHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                      <soap:Body><CreateUserResponse><Identifier>U-PRI-1</Identifier></CreateUserResponse></soap:Body>
+                    </soap:Envelope>
+                    """, Encoding.UTF8, "text/xml")
+            });
+
+        var sut = CreateSut(handler);
+        var flow = new AuthenticationFlow
+        {
+            AppId = "soap-app",
+            Name = "SOAP Priority Flow",
+            Steps = [CreateSoapFlowStep(new SOAPAuthenticationOptions
+            {
+                WsSecurity = new WsSecuritySoapAuthOptions
+                {
+                    Enabled = true,
+                    Username = "flow-step-user",
+                    Password = "flow-step-pass"
+                }
+            })]
+        };
+
+        var appConfig = CreateAppConfig(
+            authenticationFlow: flow,
+            soapAuthenticationOptions: new SOAPAuthenticationOptions
+            {
+                WsSecurity = new WsSecuritySoapAuthOptions
+                {
+                    Enabled = true,
+                    Username = "appconfig-user",
+                    Password = "appconfig-pass"
+                }
+            });
+
+        const string payload = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+              <soap:Body><CreateUser /></soap:Body>
+            </soap:Envelope>
+            """;
+
+        await sut.ProvisionAsync(payload, appConfig, "corr-flow-priority");
+
+        Assert.Contains("flow-step-user", handler.LastRequestBody);
+        Assert.DoesNotContain("appconfig-user", handler.LastRequestBody);
+    }
+
+    #endregion
+
     #region V2 ActionStep-aware tests
 
     [Fact]
@@ -834,8 +984,8 @@ public class SOAPIntegrationUnitTests
 
         var authContextMock = new Mock<IAuthContext>();
         authContextMock
-            .Setup(context => context.GetTokenAsync(It.IsAny<object>(), It.IsAny<SCIMDirections>()))
-            .Returns(Task.FromResult(token));
+            .Setup(context => context.GetTokenListAsync(It.IsAny<object>(), It.IsAny<SCIMDirections>()))
+            .ReturnsAsync(new Dictionary<int, string> { { 1, token } });
 
         var options = Options.Create(new AppSettings());
         var configuration = new ConfigurationBuilder().Build();
@@ -853,7 +1003,8 @@ public class SOAPIntegrationUnitTests
         ICollection<AttributeSchema>? schema = null,
         AuthenticationMethods authMethodOutbound = AuthenticationMethods.None,
         dynamic? authDetails = null,
-        SOAPAuthenticationOptions? soapAuthenticationOptions = null)
+        SOAPAuthenticationOptions? soapAuthenticationOptions = null,
+        AuthenticationFlow? authenticationFlow = null)
     {
         return new AppConfig
         {
@@ -876,9 +1027,22 @@ public class SOAPIntegrationUnitTests
                 }
             },
             SOAPTemplates = templates,
-            SOAPAuthenticationOptions = soapAuthenticationOptions
+#pragma warning disable CS0618
+            SOAPAuthenticationOptions = soapAuthenticationOptions,
+#pragma warning restore CS0618
+            AuthenticationFlow = authenticationFlow
         };
     }
+
+    private static AuthenticationFlowStep CreateSoapFlowStep(dynamic authenticationDetails, int stepOrder = 1) =>
+        new()
+        {
+            StepTitle = "SOAP Auth",
+            StepOrder = stepOrder,
+            AuthenticationMethod = AuthenticationMethods.None,
+            IsRequired = true,
+            AuthenticationDetails = authenticationDetails
+        };
 
     private sealed class TestHttpMessageHandler : HttpMessageHandler
     {

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
@@ -336,14 +336,19 @@ public class SOAPIntegrationUnitTests
         var sut = CreateSut();
         var appConfig = CreateAppConfig(
                 authMethodOutbound: AuthenticationMethods.None,
-                soapAuthenticationOptions: new SOAPAuthenticationOptions
+                authenticationFlow: new AuthenticationFlow
                 {
-                    Transport = new BasicOrNtlmSoapAuthOptions
+                    AppId = "soap-app",
+                    Name = "NTLM Flow",
+                    Steps = [CreateSoapFlowStep(new SOAPAuthenticationOptions
                     {
-                        Enabled = true,
-                        UseNtlm = true,
-                        UseDefaultCredentials = false
-                    }
+                        Transport = new BasicOrNtlmSoapAuthOptions
+                        {
+                            Enabled = true,
+                            UseNtlm = true,
+                            UseDefaultCredentials = false
+                        }
+                    })]
                 });
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -370,15 +375,20 @@ public class SOAPIntegrationUnitTests
         var sut = CreateSut(handler);
         var appConfig = CreateAppConfig(
                 authMethodOutbound: AuthenticationMethods.None,
-                soapAuthenticationOptions: new SOAPAuthenticationOptions
+                authenticationFlow: new AuthenticationFlow
                 {
-                    WsSecurity = new WsSecuritySoapAuthOptions
+                    AppId = "soap-app",
+                    Name = "WsSecurity Flow",
+                    Steps = [CreateSoapFlowStep(new SOAPAuthenticationOptions
                     {
-                        Enabled = true,
-                        Username = "ws-user",
-                        Password = "ws-pass",
-                        IncludeTimestamp = true
-                    }
+                        WsSecurity = new WsSecuritySoapAuthOptions
+                        {
+                            Enabled = true,
+                            Username = "ws-user",
+                            Password = "ws-pass",
+                            IncludeTimestamp = true
+                        }
+                    })]
                 });
 
         const string payload = """
@@ -417,18 +427,23 @@ public class SOAPIntegrationUnitTests
         var sut = CreateSut(handler, "token-123");
         var appConfig = CreateAppConfig(
                 authMethodOutbound: AuthenticationMethods.Bearer,
-                soapAuthenticationOptions: new SOAPAuthenticationOptions
+                authenticationFlow: new AuthenticationFlow
                 {
-                    TokenPlacement = new SoapTokenPlacementOptions
+                    AppId = "soap-app",
+                    Name = "Token Placement Flow",
+                    Steps = [CreateSoapFlowStep(new SOAPAuthenticationOptions
                     {
-                        Enabled = true,
-                        UseAuthorizationHeader = true,
-                        CustomHttpHeaders = new Dictionary<string, string>
+                        TokenPlacement = new SoapTokenPlacementOptions
                         {
-                            ["X-SOAP-Token"] = "{{token}}"
-                        },
-                        SoapHeaderTemplate = "<auth:Token xmlns:auth='urn:test'>{{token}}</auth:Token>"
-                    }
+                            Enabled = true,
+                            UseAuthorizationHeader = true,
+                            CustomHttpHeaders = new Dictionary<string, string>
+                            {
+                                ["X-SOAP-Token"] = "{{token}}"
+                            },
+                            SoapHeaderTemplate = "<auth:Token xmlns:auth='urn:test'>{{token}}</auth:Token>"
+                        }
+                    })]
                 });
 
         const string payload = """
@@ -587,10 +602,8 @@ public class SOAPIntegrationUnitTests
     }
 
     [Fact]
-    public async Task SOAPAuthOptions_FlowStepTakesPriorityOver_AppConfigProperty()
+    public async Task SOAPAuthOptions_ResolvedFromFlowStep_WsSecurityCredentialsAreApplied()
     {
-        // Both flow step and AppConfig.SOAPAuthenticationOptions are set with different usernames.
-        // Asserts the flow step value (priority-1) wins over the typed property (priority-2).
         var handler = new TestHttpMessageHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -617,17 +630,7 @@ public class SOAPIntegrationUnitTests
             })]
         };
 
-        var appConfig = CreateAppConfig(
-            authenticationFlow: flow,
-            soapAuthenticationOptions: new SOAPAuthenticationOptions
-            {
-                WsSecurity = new WsSecuritySoapAuthOptions
-                {
-                    Enabled = true,
-                    Username = "appconfig-user",
-                    Password = "appconfig-pass"
-                }
-            });
+        var appConfig = CreateAppConfig(authenticationFlow: flow);
 
         const string payload = """
             <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
@@ -637,8 +640,8 @@ public class SOAPIntegrationUnitTests
 
         await sut.ProvisionAsync(payload, appConfig, "corr-flow-priority");
 
+        Assert.Contains("wsse:Security", handler.LastRequestBody);
         Assert.Contains("flow-step-user", handler.LastRequestBody);
-        Assert.DoesNotContain("appconfig-user", handler.LastRequestBody);
     }
 
     #endregion
@@ -1003,7 +1006,6 @@ public class SOAPIntegrationUnitTests
         ICollection<AttributeSchema>? schema = null,
         AuthenticationMethods authMethodOutbound = AuthenticationMethods.None,
         dynamic? authDetails = null,
-        SOAPAuthenticationOptions? soapAuthenticationOptions = null,
         AuthenticationFlow? authenticationFlow = null)
     {
         return new AppConfig
@@ -1027,9 +1029,6 @@ public class SOAPIntegrationUnitTests
                 }
             },
             SOAPTemplates = templates,
-#pragma warning disable CS0618
-            SOAPAuthenticationOptions = soapAuthenticationOptions,
-#pragma warning restore CS0618
             AuthenticationFlow = authenticationFlow
         };
     }


### PR DESCRIPTION
This pull request refactors how SOAP authentication options are configured and resolved in the application, migrating from a legacy property on `AppConfig` to a more flexible, flow-step-based approach. The main goal is to ensure that all SOAP authentication credentials are passed through `AuthenticationFlowStep.AuthenticationDetails`, aligning SOAP integrations with other authentication methods. The changes also introduce new helper methods for extracting authentication options, update the resolution priority, and add comprehensive tests to ensure correct behavior and backward compatibility.

**Key changes:**

### Authentication Options Resolution

- **Migrated resolution of `SOAPAuthenticationOptions` to flow steps:**  
  The code now resolves SOAP authentication options first from `AuthenticationFlow.Steps[*].AuthenticationDetails` (in step order), falling back to the obsolete `AppConfig.SOAPAuthenticationOptions` property only if no step provides options. This makes the authentication configuration more flexible and future-proof. [[1]](diffhunk://#diff-3075972bf2217e7ab24fac5306b6c1893222a2fcc3853f8e4c0d3d1014140829L426-L485) [[2]](diffhunk://#diff-4b47cbabc96dfe521829e2425e44b51d724263c5dfc73265fea1f3eeef53dd81R1-R147)

- **Introduced helper methods for extracting SOAP authentication:**  
  Added `TryDeserializeSoapAuthDirectly` and `TryExtractSoapAuthFromDetails` to robustly extract `SOAPAuthenticationOptions` from dynamic `AuthenticationDetails`, supporting both direct object and nested key shapes. [[1]](diffhunk://#diff-3075972bf2217e7ab24fac5306b6c1893222a2fcc3853f8e4c0d3d1014140829L426-L485) [[2]](diffhunk://#diff-4b47cbabc96dfe521829e2425e44b51d724263c5dfc73265fea1f3eeef53dd81R1-R147)

### Backward Compatibility

- **Marked `AppConfig.SOAPAuthenticationOptions` as obsolete:**  
  The property is now decorated with `[Obsolete]` and should be set via flow steps going forward. The fallback remains for existing configurations. [[1]](diffhunk://#diff-78816b67115b08a219936fab732f3b11f5e79aa1715183707cdd85109368f5ebR49-R50) [[2]](diffhunk://#diff-4b47cbabc96dfe521829e2425e44b51d724263c5dfc73265fea1f3eeef53dd81R1-R147)

### Test Coverage

- **Added new unit tests for flow-step-based SOAP authentication:**  
  Three new tests verify resolution from direct and nested shapes in flow steps, and that flow step values take priority over the obsolete property. [[1]](diffhunk://#diff-59c14db2c70d152c1baf63b1b5cdd78147356cfc86fc30a69cd412b29a154997R496-R645) [[2]](diffhunk://#diff-4b47cbabc96dfe521829e2425e44b51d724263c5dfc73265fea1f3eeef53dd81R1-R147)

### Model Enhancements

- **Extended `BasicOrNtlmSoapAuthOptions` and `WsSecuritySoapAuthOptions`:**  
  Both records now support `KeyVaultReference` and `EncryptedData` fields for improved credential management and potential future security enhancements. [[1]](diffhunk://#diff-5e8f2bc7d75a3183b608d071915a6dca9c08f9854d9b474739c95a8b020daf64R20-R21) [[2]](diffhunk://#diff-5e8f2bc7d75a3183b608d071915a6dca9c08f9854d9b474739c95a8b020daf64R30-R31)

---

These changes modernize the SOAP authentication configuration, improve testability, and ensure backward compatibility during migration.