### PR TITLE
Refactor SOAP integration to use ActionStep for payload mapping

### DIFF
--- a/.github/prompts/plan-soapintegration-changes-with-new-appconfig.md
+++ b/.github/prompts/plan-soapintegration-changes-with-new-appconfig.md
@@ -1,0 +1,350 @@
+# Plan: SOAP Integration Changes for New AppConfig Structure
+
+## Context
+
+The AppConfig structure has changed. SOAP XML templates are no longer stored as a separate
+`AppConfig.SOAPTemplates` collection. They now live directly on each `ActionStep` as a `template`
+property. Every SOAP action contains exactly one `ActionStep`.
+
+Old shape:
+```
+AppConfig.SOAPTemplates[ { Template, Action: SOAPActions } ]
+AppConfig.Actions[ { ActionSteps[ { EndPoint, HttpVerb, UserAttributeSchemas } ] } ]
+```
+
+New shape:
+```
+AppConfig.Actions[ { ActionSteps[ { EndPoint, HttpVerb, template, UserAttributeSchemas } ] } ]
+```
+
+Relevant enums:
+- `ActionNames`: GET=1, CREATE=2, EDIT=3, DELETE=4
+- `SOAPActions`: Create, Update, Delete, Get  (becomes unused — see Step 2)
+
+---
+
+## Step 1 — Domain: Add `Template` to `ActionStep`
+
+**File:** `KN.KloudIdentity.Mapper.Domain/Application/ActionStep.cs`
+
+Add one property:
+```csharp
+public string? Template { get; init; }
+```
+
+JSON key in AppConfig is lowercase `template` — verify that the deserializer is
+case-insensitive (it is: `AppConfigSnapshotRepository` uses `PropertyNameCaseInsensitive = true`),
+so no converter is needed.
+
+---
+
+## Step 2 — Domain: Remove `SOAPTemplates` from `AppConfig` and delete dead types
+
+**File:** `KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs`
+
+Remove:
+```csharp
+public ICollection<SOAPTemplate>? SOAPTemplates { get; set; }
+```
+
+Also remove the `Validate()` guard that references `UserAttributeSchemas` for non-REST methods
+only if it becomes incorrect; otherwise leave it.
+
+**Files to delete** once nothing references them:
+- `KN.KloudIdentity.Mapper.Domain/Application/SOAPTemplate.cs`
+- `KN.KloudIdentity.Mapper.Domain/Mapping/SOAPActions.cs`
+
+> Do not delete until Steps 3–7 are complete and the build is green.
+
+---
+
+## Step 3 — SOAPIntegration: Remove `ResolveSoapTemplate` and `MapHttpVerbToSoapAction`
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs`
+
+These two helpers exist solely to look up a template from `AppConfig.SOAPTemplates`:
+
+- `protected static SOAPTemplate ResolveSoapTemplate(AppConfig, SOAPActions)` — **delete**
+- `protected static SOAPActions MapHttpVerbToSoapAction(HttpVerbs, string)` — **delete**
+
+Before deleting, fix every call site first (Steps 4 and 5).
+
+---
+
+## Step 4 — SOAPIntegration: Fix ActionStep overloads that still use `ResolveSoapTemplate`
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs`
+
+### 4a. `GetAsync(identifier, appConfig, actionStep, correlationId, cancellationToken)` — lines ~170–186
+
+Replace:
+```csharp
+var soapAction = MapHttpVerbToSoapAction(actionStep.HttpVerb, "GET");
+SOAPTemplate template = ResolveSoapTemplate(appConfig, soapAction);
+// ...
+var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template.Template, attributes, resource);
+```
+
+With:
+```csharp
+var template = actionStep.Template
+    ?? throw new InvalidOperationException(
+        $"ActionStep {actionStep.StepOrder} has no template for GET. AppId: {appConfig.AppId}");
+var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, attributes, resource);
+```
+
+### 4b. `DeleteAsync(identifier, appId, appConfig, actionStep, correlationId, cancellationToken)` — lines ~213–228
+
+Replace:
+```csharp
+var soapAction = MapHttpVerbToSoapAction(actionStep.HttpVerb, "DELETE");
+SOAPTemplate template = ResolveSoapTemplate(appConfig, soapAction);
+// ...
+var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template.Template, attributes, resource);
+```
+
+With:
+```csharp
+var template = actionStep.Template
+    ?? throw new InvalidOperationException(
+        $"ActionStep {actionStep.StepOrder} has no template for DELETE. AppId: {appConfig.AppId}");
+var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, attributes, resource);
+```
+
+---
+
+## Step 5 — SOAPIntegration: Replace `MapAndPreparePayloadAsync` with ActionStep-aware overload
+
+The existing `MapAndPreparePayloadAsync(schema, resource, appConfig)` reads
+`appConfig.SOAPTemplates?.FirstOrDefault()`. Since the template is now on `ActionStep`,
+add a new overload and retire the old one.
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs`
+
+### 5a. Add new overload
+
+```csharp
+public virtual async Task<dynamic> MapAndPreparePayloadAsync(
+    IList<AttributeSchema> schema,
+    Core2EnterpriseUser resource,
+    AppConfig appConfig,
+    ActionStep actionStep,
+    CancellationToken cancellationToken = default)
+{
+    var template = actionStep.Template
+        ?? throw new InvalidOperationException(
+            $"ActionStep {actionStep.StepOrder} has no template. AppId: {appConfig.AppId}");
+
+    string payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, schema, resource);
+    return await Task.FromResult(payload);
+}
+```
+
+### 5b. Change the old AppConfig-only overload to throw
+
+The 3-param overload `MapAndPreparePayloadAsync(schema, resource, appConfig)` is no longer
+usable for SOAP. Change its body to:
+```csharp
+throw new NotSupportedException(
+    "SOAP payload mapping requires an ActionStep. Use the overload that accepts ActionStep.");
+```
+
+This keeps the interface contract intact while making misuse visible at runtime immediately.
+
+### 5c. Add the new overload to the interface
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/IIntegrationBase.cs` (or wherever
+`MapAndPreparePayloadAsync(schema, resource, AppConfig)` is declared)
+
+Add:
+```csharp
+Task<dynamic> MapAndPreparePayloadAsync(
+    IList<AttributeSchema> schema,
+    Core2EnterpriseUser resource,
+    AppConfig appConfig,
+    ActionStep actionStep,
+    CancellationToken cancellationToken = default);
+```
+
+---
+
+## Step 6 — EagleSOAPIntegration: Switch to ActionStep-based template access
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/EagleSOAPIntegration.cs`
+
+### 6a. Override the new `MapAndPreparePayloadAsync` overload (Step 5a)
+
+Remove the current override that reads `appConfig.SOAPTemplates?.FirstOrDefault()` and
+patches a new `AppConfig`. Replace it with an override of the new ActionStep signature:
+
+```csharp
+public override async Task<dynamic> MapAndPreparePayloadAsync(
+    IList<AttributeSchema> schema,
+    Core2EnterpriseUser resource,
+    AppConfig appConfig,
+    ActionStep actionStep,
+    CancellationToken cancellationToken = default)
+{
+    var template = actionStep.Template
+        ?? throw new InvalidOperationException(
+            $"ActionStep {actionStep.StepOrder} has no template. AppId: {appConfig.AppId}");
+
+    var injected = template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
+    string payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(injected, schema, resource);
+    return await Task.FromResult(payload);
+}
+```
+
+No need to patch `AppConfig with { SOAPTemplates = ... }` anymore.
+
+### 6b. `DeleteAsync` ActionStep overload — lines ~180–202
+
+Replace:
+```csharp
+var template = ResolveSoapTemplate(appConfig, MapHttpVerbToSoapAction(actionStep.HttpVerb, "DELETE"));
+// ...
+var injected = template.Template.Replace("{{CorrelationId}}", ...);
+```
+
+With:
+```csharp
+var template = actionStep.Template
+    ?? throw new InvalidOperationException(
+        $"ActionStep {actionStep.StepOrder} has no template for DELETE. AppId: {appConfig.AppId}");
+var injected = template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
+```
+
+### 6c. Legacy overloads (no ActionStep) — `DeleteAsync` line ~154, `ReplaceAsync` line ~93, `UpdateAsync` line ~125
+
+These read from `appConfig.UserURIs` and `appConfig.SOAPTemplates`. They are only reachable via
+`ExecuteGenericUser*` paths, which for SOAP/SOAPEagle are never taken in V4. Make each throw:
+```csharp
+throw new NotSupportedException("Use the ActionStep overload for SOAPEagle operations.");
+```
+
+---
+
+## Step 7 — ProvisioningBase: Remove `GetMappingConfigForSoapAction`
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/Outbound/ProvisioningBase.cs`
+
+Delete the entire `GetMappingConfigForSoapAction(AppConfig, SOAPActions)` method (lines ~86–102).
+Its only job was to create a scoped `AppConfig` with one filtered `SOAPTemplate` — no longer needed.
+
+---
+
+## Step 8 — CreateUserV4: Use ActionStep-aware payload mapping
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs`
+
+### 8a. `ExecuteMultistepForRESTAsync` — lines ~77–80
+
+Replace:
+```csharp
+var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Create);
+var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
+var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, config);
+```
+
+With:
+```csharp
+var payload = (_appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP
+               || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAPEagle)
+    ? await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig, step, CancellationToken.None)
+    : await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig);
+```
+
+`step` is already in scope from the `foreach` loop.
+
+### 8b. `ExecuteGenericUserCreationLogicAsync` — lines ~171–174
+
+This path is unreachable for SOAP since `ExecuteAsync` always routes SOAP through
+`ExecuteMultistepForRESTAsync`. Replace the SOAP-specific `GetMappingConfigForSoapAction` call
+with a guard:
+```csharp
+if (_appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP
+    || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAPEagle)
+    throw new NotSupportedException("SOAP requires action steps. Check AppConfig.Actions.");
+```
+
+Or simply remove the SOAP/SOAPEagle branch from the `GetUserAttributes` switch and let it fall
+through to the default (which returns all attributes) — harmless since this path is dead for SOAP.
+
+---
+
+## Step 9 — ReplaceUserV4: Use ActionStep-aware payload mapping
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs`
+
+### 9a. `ExecuteMultistepForRESTAsync` — lines ~75–79
+
+Replace:
+```csharp
+var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
+var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
+var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource, config);
+```
+
+With:
+```csharp
+var payload = (_appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP
+               || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAPEagle)
+    ? await integrationOp.MapAndPreparePayloadAsync(attributes, resource, _appConfig, step, CancellationToken.None)
+    : await integrationOp.MapAndPreparePayloadAsync(attributes, resource, _appConfig);
+```
+
+### 9b. `ExecuteGenericUserReplaceLogicAsync` — line ~110
+
+Same as Step 8b — remove the `GetMappingConfigForSoapAction` call; guard or simplify.
+
+---
+
+## Step 10 — Delete dead files
+
+Once the build is green with no remaining references:
+
+1. Delete `KN.KloudIdentity.Mapper.Domain/Application/SOAPTemplate.cs`
+2. Delete `KN.KloudIdentity.Mapper.Domain/Mapping/SOAPActions.cs`
+
+Run a final grep for `SOAPTemplate` and `SOAPActions` to confirm zero references.
+
+---
+
+## Step 11 — Update Tests
+
+Search for `SOAPTemplates` across all test projects and update each occurrence:
+
+**Pattern to find:** `SOAPTemplates = [` or `SOAPTemplates =`
+
+**What to do:** Remove the `SOAPTemplates` initializer from the `AppConfig` setup and instead set
+`Template = "..."` on the relevant `ActionStep` in `ActionSteps`.
+
+Key test files likely affected (search `*Tests*.cs` for `SOAPTemplates`):
+- `DeleteUserV4Test.cs`
+- `ReplaceUserV4Tests.cs`
+- Any `SOAPIntegration` unit tests
+- Any `EagleSOAPIntegration` unit tests
+
+For each test that previously used `GetMappingConfigForSoapAction` indirectly, verify the test
+still covers the correct path.
+
+---
+
+## Execution Order Summary
+
+| Step | File(s) | Change Type |
+|------|---------|-------------|
+| 1 | `ActionStep.cs` | Add `Template` property |
+| 2 | `AppConfig.cs` | Remove `SOAPTemplates` |
+| 3 | `SOAPIntegration.cs` | Delete `ResolveSoapTemplate` + `MapHttpVerbToSoapAction` |
+| 4 | `SOAPIntegration.cs` | Fix `GetAsync` + `DeleteAsync` ActionStep overloads |
+| 5 | `SOAPIntegration.cs` + interface | New `MapAndPreparePayloadAsync` ActionStep overload |
+| 6 | `EagleSOAPIntegration.cs` | Switch all template access to `actionStep.Template` |
+| 7 | `ProvisioningBase.cs` | Delete `GetMappingConfigForSoapAction` |
+| 8 | `CreateUserV4.cs` | Use ActionStep-aware payload mapping |
+| 9 | `ReplaceUserV4.cs` | Use ActionStep-aware payload mapping |
+| 10 | `SOAPTemplate.cs`, `SOAPActions.cs` | Delete files |
+| 11 | Test projects | Update all `SOAPTemplates` → `ActionStep.Template` |
+
+Build after each step. Steps 1 and 2 will cause compile errors that Steps 3–9 resolve.
+It is safe to do Steps 1–9 in one pass before building if preferred.

--- a/KN.KloudIdentity.Mapper.Domain/Application/ActionStep.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/ActionStep.cs
@@ -36,6 +36,11 @@ public class ActionStep
     public bool? IsMandatory { get; init; } = true;
 
     /// <summary>
+    /// SOAP XML template with {{Placeholder}} markers. Only used for SOAP integration methods.
+    /// </summary>
+    public string? Template { get; init; }
+
+    /// <summary>
     /// List of User Attribute Schemas
     /// </summary>
     public virtual ICollection<AttributeSchema>? UserAttributeSchemas { get; init; }

--- a/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs
@@ -45,5 +45,4 @@ public record AppConfig
             throw new InvalidOperationException($"UserAttributeSchemas must be provided for {IntegrationMethodOutbound} integration method.");
         }
     }
-    public ICollection<SOAPTemplate>? SOAPTemplates { get; set; }
 }

--- a/KN.KloudIdentity.Mapper.Domain/Application/SOAPTemplate.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Application/SOAPTemplate.cs
@@ -1,8 +1,0 @@
-using KN.KloudIdentity.Mapper.Domain.Mapping;
-
-namespace KN.KloudIdentity.Mapper.Domain.Application;
-
-public record SOAPTemplate(
-    string Template,
-    SOAPActions Action
-);

--- a/KN.KloudIdentity.Mapper.Domain/Mapping/SOAPActions.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Mapping/SOAPActions.cs
@@ -1,9 +1,0 @@
-namespace KN.KloudIdentity.Mapper.Domain.Mapping;
-
-public enum SOAPActions
-{
-    Create,
-    Update,
-    Delete,
-    Get
-}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/EagleSOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/EagleSOAPIntegration.cs
@@ -165,6 +165,12 @@ public class EagleSOAPIntegration : SOAPIntegration
         var attributes = actionStep.UserAttributeSchemas?.ToList()
             ?? throw new InvalidOperationException($"No attributes configured on ActionStep {actionStep.StepOrder} for DELETE. AppId: {appConfig.AppId}");
 
+        if (attributes.Count == 0)
+            throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no attributes for DELETE. AppId: {appConfig.AppId}");
+
+        if (!attributes.Any(a => a.DestinationField == "Identifier"))
+            throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} is missing an Identifier attribute mapping for DELETE. AppId: {appConfig.AppId}");
+
         var resource = new Core2EnterpriseUser { Identifier = identifier };
         var injected = template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
         var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(injected, attributes, resource);

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/EagleSOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/EagleSOAPIntegration.cs
@@ -42,16 +42,15 @@ public class EagleSOAPIntegration : SOAPIntegration
         IList<AttributeSchema> schema,
         Core2EnterpriseUser resource,
         AppConfig appConfig,
+        ActionStep actionStep,
         CancellationToken cancellationToken = default)
     {
-        var template = appConfig.SOAPTemplates?.FirstOrDefault()
-            ?? throw new InvalidOperationException($"SOAP template required. AppId: {appConfig.AppId}");
+        var template = actionStep.Template
+            ?? throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no template. AppId: {appConfig.AppId}");
 
-        // Inject {{CorrelationId}} before delegating to base
-        var injected = template.Template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
-        var patchedConfig = appConfig with { SOAPTemplates = [new SOAPTemplate(injected, template.Action)] };
-
-        return await base.MapAndPreparePayloadAsync(schema, resource, patchedConfig, cancellationToken);
+        var injected = template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
+        string payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(injected, schema, resource);
+        return await Task.FromResult(payload);
     }
 
     public override async Task<Core2EnterpriseUser?> ProvisionAsync(
@@ -90,17 +89,13 @@ public class EagleSOAPIntegration : SOAPIntegration
         return new Core2EnterpriseUser { Identifier = userId };
     }
 
-    public override async Task ReplaceAsync(
+    public override Task ReplaceAsync(
         dynamic payload,
         Core2EnterpriseUser resource,
         AppConfig appConfig,
         string correlationId)
     {
-        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Put
-            ?? throw new InvalidOperationException("Eagle Replace endpoint not configured.");
-
-        var responseBody = await SendSoapRequestAsync(userUri, payload, appConfig, SCIMDirections.Outbound, correlationId);
-        CheckEagleAck(responseBody, appConfig.AppId);
+        throw new NotSupportedException("Use the ActionStep overload for SOAPEagle operations.");
     }
 
     public override async Task<Core2EnterpriseUser> ReplaceAsync(
@@ -122,18 +117,13 @@ public class EagleSOAPIntegration : SOAPIntegration
         return resource; // preserve caller's resource.Identifier — Eagle ACK carries correlationId, not the user ID
     }
 
-    public override async Task UpdateAsync(
+    public override Task UpdateAsync(
         dynamic payload,
         Core2EnterpriseUser resource,
         AppConfig appConfig,
         string correlationId)
     {
-        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Patch
-                   ?? appConfig.UserURIs?.FirstOrDefault()?.Put
-                   ?? throw new InvalidOperationException("Eagle Update endpoint not configured.");
-
-        var responseBody = await SendSoapRequestAsync(userUri, payload, appConfig, SCIMDirections.Outbound, correlationId);
-        CheckEagleAck(responseBody, appConfig.AppId);
+        throw new NotSupportedException("Use the ActionStep overload for SOAPEagle operations.");
     }
 
     public override async Task UpdateAsync(
@@ -151,30 +141,12 @@ public class EagleSOAPIntegration : SOAPIntegration
         CheckEagleAck(responseBody, appConfig.AppId);
     }
 
-    public override async Task DeleteAsync(
+    public override Task DeleteAsync(
         string identifier,
         AppConfig appConfig,
         string correlationId)
     {
-        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Delete
-            ?? throw new InvalidOperationException("Eagle Delete endpoint not configured.");
-
-        var template = appConfig.SOAPTemplates?.FirstOrDefault(t => t.Action == SOAPActions.Delete)
-            ?? throw new InvalidOperationException($"SOAP template for DELETE action not configured. AppId: {appConfig.AppId}");
-
-        var attributes = (appConfig.UserAttributeSchemas ?? Array.Empty<AttributeSchema>())
-            .Where(p => p.HttpRequestType == HttpRequestTypes.DELETE)
-            .ToList();
-
-        if (attributes.Count == 0 || !attributes.Any(a => a.SourceValue.Equals("Identifier", StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"DELETE attribute schema must include an Identifier mapping. AppId: {appConfig.AppId}");
-
-        var resource = new Core2EnterpriseUser { Identifier = identifier };
-        var injected = template.Template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
-        var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(injected, attributes, resource);
-
-        var responseBody = await SendSoapRequestAsync(userUri, soapPayload, appConfig, SCIMDirections.Outbound, correlationId);
-        CheckEagleAck(responseBody, appConfig.AppId);
+        throw new NotSupportedException("Use the ActionStep overload for SOAPEagle operations.");
     }
    
     public override async Task DeleteAsync(
@@ -187,14 +159,14 @@ public class EagleSOAPIntegration : SOAPIntegration
     {
         ValidateActionStep(actionStep, "DELETE");
 
-        var template = ResolveSoapTemplate(appConfig, MapHttpVerbToSoapAction(actionStep.HttpVerb, "DELETE"));
+        var template = actionStep.Template
+            ?? throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no template for DELETE. AppId: {appConfig.AppId}");
+
         var attributes = actionStep.UserAttributeSchemas?.ToList()
             ?? throw new InvalidOperationException($"No attributes configured on ActionStep {actionStep.StepOrder} for DELETE. AppId: {appConfig.AppId}");
 
         var resource = new Core2EnterpriseUser { Identifier = identifier };
-
-         // Inject {{CorrelationId}} into template + ACK check
-        var injected = template.Template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
+        var injected = template.Replace("{{CorrelationId}}", Guid.NewGuid().ToString(), StringComparison.Ordinal);
         var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(injected, attributes, resource);
 
         var responseBody = await SendSoapRequestAsync(new Uri(actionStep.EndPoint), soapPayload, appConfig, SCIMDirections.Outbound, correlationId, cancellationToken);

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/IIntegrationBase.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/IIntegrationBase.cs
@@ -37,6 +37,22 @@ public interface IIntegrationBase
     }
 
     /// <summary>
+    /// Attribute mapping and prepares the payload asynchronously using an action step (SOAP integrations).
+    /// Non-SOAP integrations fall back to the AppConfig-only overload.
+    /// </summary>
+    /// <param name="schema">Attribute mapping schema data</param>
+    /// <param name="resource">Entra ID object</param>
+    /// <param name="appConfig">App configuration context</param>
+    /// <param name="actionStep">Action step containing the SOAP template</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource,
+        AppConfig appConfig, ActionStep actionStep, CancellationToken cancellationToken = default)
+    {
+        return MapAndPreparePayloadAsync(schema, resource, appConfig, cancellationToken);
+    }
+
+    /// <summary>
     /// Gets the authentication token asynchronously.
     /// </summary>
     /// <param name="config">App configuration</param>

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -1,18 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Text.Json;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using KN.KI.LogAggregator.Library.Abstractions;
 using KN.KloudIdentity.Mapper.Domain;
 using KN.KloudIdentity.Mapper.Domain.Application;
 using KN.KloudIdentity.Mapper.Domain.Authentication;
 using KN.KloudIdentity.Mapper.Domain.Mapping;
-using KN.KloudIdentity.Mapper.MapperCore;
 using KN.KloudIdentity.Mapper.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -66,15 +58,15 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         }
 
         // Overload that matches the interface (does not require AppConfig)
-        public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource, CancellationToken cancellationToken = default)
+        public virtual Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException("AppConfig is required for SOAP payload mapping. Use the overload that accepts AppConfig.");
         }
 
         /// <summary>
-        /// Maps user attributes to a SOAP XML payload using the template on the ActionStep.
+        /// Not supported for SOAP. Use the overload that accepts an ActionStep.
         /// </summary>
-        public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource, AppConfig appConfig, CancellationToken cancellationToken = default)
+        public virtual Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource, AppConfig appConfig, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException("SOAP payload mapping requires an ActionStep. Use the overload that accepts ActionStep.");
         }
@@ -151,6 +143,12 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             var attributes = actionStep.UserAttributeSchemas?.ToList()
                 ?? throw new InvalidOperationException($"No attributes configured on ActionStep {actionStep.StepOrder} for GET. AppId: {appConfig.AppId}");
 
+            if (attributes.Count == 0)
+                throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no attributes for GET. AppId: {appConfig.AppId}");
+
+            if (!attributes.Any(a => a.DestinationField == "Identifier"))
+                throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} is missing an Identifier attribute mapping for GET. AppId: {appConfig.AppId}");
+
             var resource = new Core2EnterpriseUser { Identifier = identifier };
             var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, attributes, resource);
 
@@ -193,6 +191,12 @@ namespace KN.KloudIdentity.Mapper.MapperCore
 
             var attributes = actionStep.UserAttributeSchemas?.ToList()
                 ?? throw new InvalidOperationException($"No attributes configured on ActionStep {actionStep.StepOrder} for DELETE. AppId: {appConfig.AppId}");
+
+            if (attributes.Count == 0)
+                throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no attributes for DELETE. AppId: {appConfig.AppId}");
+
+            if (!attributes.Any(a => a.DestinationField == "Identifier"))
+                throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} is missing an Identifier attribute mapping for DELETE. AppId: {appConfig.AppId}");
 
             var resource = new Core2EnterpriseUser { Identifier = identifier };
             var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, attributes, resource);

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/SOAPIntegration.cs
@@ -72,26 +72,22 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         }
 
         /// <summary>
-        /// Maps user attributes to a SOAP XML payload based on the provided template in app configuration.
+        /// Maps user attributes to a SOAP XML payload using the template on the ActionStep.
         /// </summary>
-        /// <param name="schema">The list of attribute schemas to map.</param>
-        /// <param name="resource">The user resource containing the attribute values.</param>
-        /// <param name="appConfig">The application configuration containing the SOAP template. SOAPTemplates must only contain one template for the action.</param>
-        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-        /// <returns>The mapped SOAP XML payload.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if no SOAP template is configured.</exception>
         public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource, AppConfig appConfig, CancellationToken cancellationToken = default)
         {
-            // It is assumed that the SOAP template passed is the correct one for the action.
-            SOAPTemplate? template = appConfig.SOAPTemplates?.FirstOrDefault();
-            if (template == null)
-            {
-                Log.Error("No SOAP template configured. AppId: {AppId}", appConfig.AppId);
-                throw new InvalidOperationException("SOAP template is required for payload mapping.");
-            }
+            throw new NotSupportedException("SOAP payload mapping requires an ActionStep. Use the overload that accepts ActionStep.");
+        }
 
-            string payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template.Template, schema, resource);
+        /// <summary>
+        /// Maps user attributes to a SOAP XML payload using the template stored on the ActionStep.
+        /// </summary>
+        public virtual async Task<dynamic> MapAndPreparePayloadAsync(IList<AttributeSchema> schema, Core2EnterpriseUser resource, AppConfig appConfig, ActionStep actionStep, CancellationToken cancellationToken = default)
+        {
+            var template = actionStep.Template
+                ?? throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no template. AppId: {appConfig.AppId}");
 
+            string payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, schema, resource);
             return await Task.FromResult(payload);
         }
 
@@ -112,31 +108,9 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             return Task.FromResult((true, Array.Empty<string>()));
         }
 
-        public virtual async Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, string correlationId, CancellationToken cancellationToken = default)
+        public virtual Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, string correlationId, CancellationToken cancellationToken = default)
         {
-            var userUri = appConfig.UserURIs?.FirstOrDefault()?.Get ?? throw new InvalidOperationException("GET API not configured.");
-            SOAPTemplate? template = appConfig.SOAPTemplates?.FirstOrDefault(t => t.Action == SOAPActions.Get);
-            if (template == null)
-            {
-                Log.Error("No SOAP template configured for GET action. AppId: {AppId}", appConfig.AppId);
-                throw new InvalidOperationException("SOAP template is required for GET action.");
-            }
-
-            string xmlTemplate = template.Template;
-            var attributes = (appConfig.UserAttributeSchemas ?? Array.Empty<AttributeSchema>()).Where(p => p.HttpRequestType == HttpRequestTypes.GET).ToList();
-            if (!attributes.Any() || !attributes.Any(a => a.SourceValue.Equals("Identifier", StringComparison.OrdinalIgnoreCase)))
-            {
-                Log.Error("No valid attributes configured for GET action. AppId: {AppId}", appConfig.AppId);
-                throw new InvalidOperationException("At least one attribute other than Identifier must be configured for GET action.");
-            }
-
-            Core2EnterpriseUser resource = new Core2EnterpriseUser { Identifier = identifier };
-
-            var payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(xmlTemplate, attributes, resource);
-
-            string responseBody = await SendSoapRequestAsync(userUri, payload, appConfig, SCIMDirections.Outbound, correlationId, cancellationToken);
-
-            return ParseSoapUserResponse(responseBody);
+            throw new NotSupportedException("Use the ActionStep overload for SOAP GET operations.");
         }
 
         public virtual async Task ReplaceAsync(dynamic payload, Core2EnterpriseUser resource, AppConfig appConfig, string correlationId)
@@ -171,14 +145,14 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         {
             ValidateActionStep(actionStep, "GET");
 
-            var soapAction = MapHttpVerbToSoapAction(actionStep.HttpVerb, "GET");
-            SOAPTemplate template = ResolveSoapTemplate(appConfig, soapAction);
+            var template = actionStep.Template
+                ?? throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no template for GET. AppId: {appConfig.AppId}");
 
             var attributes = actionStep.UserAttributeSchemas?.ToList()
                 ?? throw new InvalidOperationException($"No attributes configured on ActionStep {actionStep.StepOrder} for GET. AppId: {appConfig.AppId}");
 
             var resource = new Core2EnterpriseUser { Identifier = identifier };
-            var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template.Template, attributes, resource);
+            var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, attributes, resource);
 
             var endpointUri = new Uri(actionStep.EndPoint);
             string responseBody = await SendSoapRequestAsync(endpointUri, soapPayload, appConfig, SCIMDirections.Outbound, correlationId, cancellationToken);
@@ -214,14 +188,14 @@ namespace KN.KloudIdentity.Mapper.MapperCore
         {
             ValidateActionStep(actionStep, "DELETE");
 
-            var soapAction = MapHttpVerbToSoapAction(actionStep.HttpVerb, "DELETE");
-            SOAPTemplate template = ResolveSoapTemplate(appConfig, soapAction);
+            var template = actionStep.Template
+                ?? throw new InvalidOperationException($"ActionStep {actionStep.StepOrder} has no template for DELETE. AppId: {appConfig.AppId}");
 
             var attributes = actionStep.UserAttributeSchemas?.ToList()
                 ?? throw new InvalidOperationException($"No attributes configured on ActionStep {actionStep.StepOrder} for DELETE. AppId: {appConfig.AppId}");
 
             var resource = new Core2EnterpriseUser { Identifier = identifier };
-            var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template.Template, attributes, resource);
+            var soapPayload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(template, attributes, resource);
 
             var endpointUri = new Uri(actionStep.EndPoint);
             await SendSoapRequestAsync(endpointUri, soapPayload, appConfig, SCIMDirections.Outbound, correlationId, cancellationToken);
@@ -241,62 +215,11 @@ namespace KN.KloudIdentity.Mapper.MapperCore
             }
         }
 
-        /// <summary>
-        /// Maps an ActionStep HttpVerb to the corresponding SOAPActions enum for template lookup.
-        /// </summary>
-        protected static SOAPActions MapHttpVerbToSoapAction(HttpVerbs httpVerb, string operationName)
-        {
-            return httpVerb switch
-            {
-                HttpVerbs.POST => SOAPActions.Create,
-                HttpVerbs.PUT => SOAPActions.Update,
-                HttpVerbs.PATCH => SOAPActions.Update,
-                HttpVerbs.DELETE => SOAPActions.Delete,
-                HttpVerbs.GET => SOAPActions.Get,
-                _ => throw new NotSupportedException(
-                    $"HttpVerb '{httpVerb}' is not supported for SOAP {operationName} operation.")
-            };
-        }
-
-        /// <summary>
-        /// Resolves the SOAP template from app configuration by action type.
-        /// </summary>
-        protected static SOAPTemplate ResolveSoapTemplate(AppConfig appConfig, SOAPActions action)
-        {
-            var template = appConfig.SOAPTemplates?.FirstOrDefault(t => t.Action == action);
-            if (template == null)
-            {
-                Log.Error("No SOAP template configured for {Action} action. AppId: {AppId}", action, appConfig.AppId);
-                throw new InvalidOperationException($"SOAP template is required for {action} action. AppId: {appConfig.AppId}");
-            }
-            return template;
-        }
-
         #endregion
 
-        public virtual async Task DeleteAsync(string identifier, AppConfig appConfig, string correlationId)
+        public virtual Task DeleteAsync(string identifier, AppConfig appConfig, string correlationId)
         {
-            var userUri = appConfig.UserURIs?.FirstOrDefault()?.Delete ?? throw new InvalidOperationException("Delete endpoint not configured.");
-            SOAPTemplate? template = appConfig.SOAPTemplates?.FirstOrDefault(t => t.Action == SOAPActions.Delete);
-            if (template == null)
-            {
-                Log.Error("No SOAP template configured for DELETE action. AppId: {AppId}", appConfig.AppId);
-                throw new InvalidOperationException("SOAP template is required for DELETE action.");
-            }
-
-            string xmlTemplate = template.Template;
-            var attributes = (appConfig.UserAttributeSchemas ?? Array.Empty<AttributeSchema>()).Where(p => p.HttpRequestType == HttpRequestTypes.DELETE).ToList();
-            if (!attributes.Any() || !attributes.Any(a => a.SourceValue.Equals("Identifier", StringComparison.OrdinalIgnoreCase)))
-            {
-                Log.Error("No valid attributes configured for DELETE action. AppId: {AppId}", appConfig.AppId);
-                throw new InvalidOperationException("At least one attribute other than Identifier must be configured for DELETE action.");
-            }
-
-            Core2EnterpriseUser resource = new Core2EnterpriseUser { Identifier = identifier };
-
-            var payload = SOAPParserUtil<Core2EnterpriseUser>.BuildPayload(xmlTemplate, attributes, resource);
-
-            await SendSoapRequestAsync(userUri, payload, appConfig, SCIMDirections.Outbound, correlationId);
+            throw new NotSupportedException("Use the ActionStep overload for SOAP DELETE operations.");
         }
         /// <summary>
         /// Sends a SOAP request to the specified URI with the given payload and handles common response logic.

--- a/KN.KloudIdentity.Mapper/MapperCore/Outbound/ProvisioningBase.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/Outbound/ProvisioningBase.cs
@@ -1,10 +1,8 @@
 using KN.KloudIdentity.Mapper.Common.Exceptions;
 using KN.KloudIdentity.Mapper.Domain.Application;
-using KN.KloudIdentity.Mapper.Domain.Mapping;
 using KN.KloudIdentity.Mapper.Infrastructure.Persistence.Abstractions;
 using KN.KloudIdentity.Mapper.MapperCore.Outbound.CustomLogic;
 using Serilog;
-using System.Linq;
 
 namespace KN.KloudIdentity.Mapper.MapperCore.Outbound;
 
@@ -79,25 +77,4 @@ public class ProvisioningBase(
         return config;
     }
 
-    /// <summary>
-    /// Returns an app config scoped to a single SOAP action template for payload mapping.
-    /// For non-SOAP integrations, returns the original configuration instance.
-    /// </summary>
-    protected AppConfig GetMappingConfigForSoapAction(AppConfig appConfig, SOAPActions action)
-    {
-        if (appConfig.IntegrationMethodOutbound != IntegrationMethods.SOAP
-            && appConfig.IntegrationMethodOutbound != IntegrationMethods.SOAPEagle)
-        {
-            return appConfig;
-        }
-
-        var scopedTemplates = appConfig.SOAPTemplates?
-            .Where(template => template.Action == action)
-            .ToList();
-
-        return appConfig with
-        {
-            SOAPTemplates = scopedTemplates
-        };
-    }
 }

--- a/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV2.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV2.cs
@@ -59,11 +59,8 @@ public class CreateUserV2 : ProvisioningBase, ICreateResourceV2
 
         // Step 2: Attribute mapping
 
-        // For SOAP, we need to get the specific mapping config for the Create action. For other integration methods, we can pass the whole appConfig.
-        var mappingConfig = GetMappingConfigForSoapAction(appConfig, SOAPActions.Create);
-
         var userAttributes = GetUserAttributes(appConfig.UserAttributeSchemas, appConfig.IntegrationMethodOutbound);
-        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, mappingConfig);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, appConfig);
         Log.Information(
             "Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",
             appId, correlationID, JsonConvert.SerializeObject(payload));

--- a/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV2.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV2.cs
@@ -52,6 +52,10 @@ public class CreateUserV2 : ProvisioningBase, ICreateResourceV2
         // Step 1: Get app config
         var appConfig = await GetAppConfigAsync(appId);
 
+        if (appConfig.IntegrationMethodOutbound is IntegrationMethods.SOAP or IntegrationMethods.SOAPEagle)
+            throw new NotSupportedException(
+                $"CreateUserV2 does not support SOAP integrations. Use CreateUserV4 for AppId: {appId}.");
+
         // Resolve integration method operations
         var integrationOp = _integrationBaseFactory.GetIntegration(appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST, appId) ??
                                 throw new NotSupportedException($"Integration method {appConfig.IntegrationMethodOutbound} is not supported.");

--- a/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/CreateUserV4.cs
@@ -73,11 +73,11 @@ public class CreateUserV4(
             // Attribute mapping
             var userAttributes = step.UserAttributeSchemas?.ToList() ?? [];
 
-            // For SOAP, we need to get the specific mapping config for the Create action. For other integration methods, we can pass the whole appConfig.
-            var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Create);
-
-            var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
-            var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, config);            
+            var isSoap = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP
+                         || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAPEagle;
+            var payload = isSoap
+                ? await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig, step, CancellationToken.None)
+                : await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig);            
             
             Log.Information(
                 "Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Step: {Step}, Payload: {Payload}",
@@ -167,11 +167,8 @@ public class CreateUserV4(
                                 throw new NotSupportedException($"Integration method {_appConfig.IntegrationMethodOutbound} is not supported.");
 
         // Step 2: Attribute mapping
-        // For SOAP, we need to get the specific mapping config for the Create action. For other integration methods, we can pass the whole appConfig.
-        var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Create);
-
         var userAttributes = GetUserAttributes(_appConfig.UserAttributeSchemas, _appConfig.IntegrationMethodOutbound);
-        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, mappingConfig);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig);
         Log.Information(
             "Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",
             appId, correlationID, JsonConvert.SerializeObject(payload));

--- a/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV2.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV2.cs
@@ -55,11 +55,7 @@ public class ReplaceUserV2 : ProvisioningBase, IReplaceResourceV2
         var attributes = GetUserAttributes(appConfig.UserAttributeSchemas, appConfig.IntegrationMethodOutbound);
 
         // Step 2: Map and prepare payload
-
-        // For SOAP, we need to get the specific mapping config for the Update action. For other integration methods, we can pass the whole appConfig.
-        var mappingConfig = GetMappingConfigForSoapAction(appConfig, SOAPActions.Update);
-
-        var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource, mappingConfig);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource, appConfig);
         Log.Information(
             "Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",
             appId, correlationID, JsonConvert.SerializeObject(payload));

--- a/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV2.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV2.cs
@@ -45,6 +45,10 @@ public class ReplaceUserV2 : ProvisioningBase, IReplaceResourceV2
         // Step 1: Get app config
         var appConfig = await GetAppConfigAsync(appId);
 
+        if (appConfig.IntegrationMethodOutbound is IntegrationMethods.SOAP or IntegrationMethods.SOAPEagle)
+            throw new NotSupportedException(
+                $"ReplaceUserV2 does not support SOAP integrations. Use ReplaceUserV4 for AppId: {appId}.");
+
         // Resolve integration method operations
         var integrationOp =
             _integrationBaseFactory.GetIntegration(appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,

--- a/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/ReplaceUserV4.cs
@@ -71,12 +71,11 @@ public class ReplaceUserV4(
 
             var attributes = step.UserAttributeSchemas?.ToList() ?? [];
 
-            // Map the user resource to the outbound payload
-            var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
-
-            var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
-
-            var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, resource, config);
+            var isSoap = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP
+                         || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAPEagle;
+            var payload = isSoap
+                ? await integrationOp.MapAndPreparePayloadAsync(attributes, resource, _appConfig, step, CancellationToken.None)
+                : await integrationOp.MapAndPreparePayloadAsync(attributes, resource, _appConfig);
             
             Log.Information($"[ReplaceUserV4] Payload mapped and prepared successfully for ActionStep {step.StepOrder}, AppId: {appId}, CorrelationID: {correlationID}");
 
@@ -106,10 +105,7 @@ public class ReplaceUserV4(
 
         var userAttributes = GetUserAttributes(_appConfig.UserAttributeSchemas, _appConfig.IntegrationMethodOutbound);
 
-        // For SOAP, we need to get the specific mapping config for the Update action. For other integration methods, we can pass the whole appConfig.
-        var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
-
-        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, mappingConfig);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, resource, _appConfig);
         Log.Information(
             "[ReplaceUserV4] Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",
             appId, correlationID, JsonConvert.SerializeObject(payload));

--- a/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV2.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV2.cs
@@ -55,6 +55,10 @@ public class UpdateUserV2 : ProvisioningBase, IUpdateResourceV2
         // Step 1: Get app config
         var appConfig = await GetAppConfigAsync(appId);
 
+        if (appConfig.IntegrationMethodOutbound is IntegrationMethods.SOAP or IntegrationMethods.SOAPEagle)
+            throw new NotSupportedException(
+                $"UpdateUserV2 does not support SOAP integrations. Use UpdateUserV4 for AppId: {appId}.");
+
         var integrationOp =
             _integrationBaseFactory.GetIntegration(appConfig.IntegrationMethodOutbound ?? IntegrationMethods.REST,
                 appId) ??

--- a/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV2.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV2.cs
@@ -64,11 +64,7 @@ public class UpdateUserV2 : ProvisioningBase, IUpdateResourceV2
         var attributes = GetUserAttributes(appConfig.UserAttributeSchemas, appConfig.IntegrationMethodOutbound);
 
         // Step 2: Map and prepare payload
-
-        // For SOAP, we need to get the specific mapping config for the Update action. For other integration methods, we can pass the whole appConfig.
-        var mappingConfig = GetMappingConfigForSoapAction(appConfig, SOAPActions.Update);
-
-        var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, user, mappingConfig);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, user, appConfig);
         Log.Information(
             "Payload mapped and prepared successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
             user.Identifier, appId, correlationId);

--- a/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/User/UpdateUserV4.cs
@@ -79,11 +79,10 @@ public class UpdateUserV4(
         {
             var attributes = step.UserAttributeSchemas?.ToList() ?? [];
 
-            // For SOAP, we need to get the specific mapping config for the Update action. For other integration methods, we can pass the whole appConfig.
-            var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
-            var config = _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP ? mappingConfig : _appConfig;
-
-            var payload = await integrationOp.MapAndPreparePayloadAsync(attributes, user, config);
+            var payload = (_appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAP
+                           || _appConfig.IntegrationMethodOutbound == IntegrationMethods.SOAPEagle)
+                ? await integrationOp.MapAndPreparePayloadAsync(attributes, user, _appConfig, step, CancellationToken.None)
+                : await integrationOp.MapAndPreparePayloadAsync(attributes, user, _appConfig);
             Log.Information(
                 "[UpdateUserV4] Payload mapped and prepared successfully for Identifier: {Identifier}, AppId: {AppId}, CorrelationID: {CorrelationID}",
                 user.Identifier, appId, correlationId);
@@ -115,9 +114,7 @@ public class UpdateUserV4(
 
         var userAttributes = GetUserAttributes(_appConfig.UserAttributeSchemas, _appConfig.IntegrationMethodOutbound);
 
-        // For SOAP, we need to get the specific mapping config for the Update action. For other integration methods, we can pass the whole appConfig.
-        var mappingConfig = GetMappingConfigForSoapAction(_appConfig, SOAPActions.Update);
-        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, user, mappingConfig);
+        var payload = await integrationOp.MapAndPreparePayloadAsync(userAttributes, user, _appConfig);
         
         Log.Information(
             "[UpdateUserV4] Payload mapped and prepared successfully for AppId: {AppId}, CorrelationID: {CorrelationID}, Payload: {Payload}",

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/EagleInvestment/EagleSOAPIntegrationTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/EagleInvestment/EagleSOAPIntegrationTests.cs
@@ -28,14 +28,11 @@ public class EagleSOAPIntegrationTests
     public async Task MapAndPreparePayloadAsync_InjectsValidGuidAsCorrelationId()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates:
-            [
-                new("<env><correlationId>{{CorrelationId}}</correlationId></env>", SOAPActions.Create)
-            ]);
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(template: "<env><correlationId>{{CorrelationId}}</correlationId></env>");
 
         var payload = await sut.MapAndPreparePayloadAsync(
-            new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig);
+            new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig, step);
 
         string result = Assert.IsType<string>(payload);
         var xmlDoc = new XmlDocument { XmlResolver = null };
@@ -50,16 +47,13 @@ public class EagleSOAPIntegrationTests
     public async Task MapAndPreparePayloadAsync_TwoConsecutiveCalls_ProduceDifferentCorrelationIds()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates:
-            [
-                new("<env><correlationId>{{CorrelationId}}</correlationId></env>", SOAPActions.Create)
-            ]);
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(template: "<env><correlationId>{{CorrelationId}}</correlationId></env>");
 
         var payload1 = await sut.MapAndPreparePayloadAsync(
-            new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig);
+            new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig, step);
         var payload2 = await sut.MapAndPreparePayloadAsync(
-            new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig);
+            new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig, step);
 
         static string ExtractCorrelationId(string xml)
         {
@@ -77,10 +71,11 @@ public class EagleSOAPIntegrationTests
     public async Task MapAndPreparePayloadAsync_WithNoTemplate_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig() with { SOAPTemplates = null };
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(template: null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.MapAndPreparePayloadAsync(new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig));
+            sut.MapAndPreparePayloadAsync(new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig, step));
     }
 
     [Fact]
@@ -92,16 +87,12 @@ public class EagleSOAPIntegrationTests
             new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct },
             new() { DestinationField = "UserName",   SourceValue = "UserName",   MappingType = MappingTypes.Direct }
         };
-        var appConfig = CreateAppConfig(
-            templates:
-            [
-                new(
-                    "<env><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId><userName>{{UserName}}</userName></env>",
-                    SOAPActions.Create)
-            ]);
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            template: "<env><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId><userName>{{UserName}}</userName></env>");
         var resource = new Core2EnterpriseUser { Identifier = "eagle-123", UserName = "john.doe" };
 
-        var payload = await sut.MapAndPreparePayloadAsync(schema, resource, appConfig);
+        var payload = await sut.MapAndPreparePayloadAsync(schema, resource, appConfig, step);
 
         string result = Assert.IsType<string>(payload);
         var xmlDoc = new XmlDocument { XmlResolver = null };
@@ -267,6 +258,7 @@ public class EagleSOAPIntegrationTests
         var appConfig = CreateAppConfig();
         var step = CreateActionStep(
             httpVerb: HttpVerbs.DELETE,
+            template: "<env><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId></env>",
             attributes:
             [
                 new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
@@ -333,24 +325,14 @@ public class EagleSOAPIntegrationTests
     public async Task DeleteAsync_WhenNoDeleteAttributesConfigured_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(); // schema = empty → no DELETE-typed attributes
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            httpVerb: HttpVerbs.DELETE,
+            template: "<env><userId>{{Identifier}}</userId></env>",
+            attributes: null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.DeleteAsync("user-001", appConfig, "corr-del-guard-1"));
-    }
-
-    [Fact]
-    public async Task DeleteAsync_WhenIdentifierMappingMissing_ThrowsInvalidOperationException()
-    {
-        var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            schema:
-            [
-                new() { DestinationField = "Email", SourceValue = "UserName", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
-            ]);
-
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.DeleteAsync("user-001", appConfig, "corr-del-guard-2"));
+            sut.DeleteAsync("user-001", "eagle-app", appConfig, step, "corr-del-guard-1"));
     }
 
     [Fact]
@@ -364,19 +346,16 @@ public class EagleSOAPIntegrationTests
                     Encoding.UTF8, "text/xml")
             });
         var sut = CreateSut(handler);
-        var appConfig = CreateAppConfig(
-            templates:
-            [
-                new("<env><action>CREATE</action><correlationId>{{CorrelationId}}</correlationId></env>", SOAPActions.Create),
-                new("<env><action>CHANGE</action><correlationId>{{CorrelationId}}</correlationId></env>",  SOAPActions.Update),
-                new("<env><action>DELETE</action><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId></env>", SOAPActions.Delete)
-            ],
-            schema:
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            httpVerb: HttpVerbs.DELETE,
+            template: "<env><action>DELETE</action><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId></env>",
+            attributes:
             [
                 new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
             ]);
 
-        await sut.DeleteAsync("user-del-001", appConfig, "corr-t18");
+        await sut.DeleteAsync("user-del-001", "eagle-app", appConfig, step, "corr-t18");
 
         Assert.Contains("<action>DELETE</action>", handler.LastRequestBody);
         Assert.Contains("user-del-001", handler.LastRequestBody);
@@ -394,10 +373,11 @@ public class EagleSOAPIntegrationTests
             });
         var sut = CreateSut(handler);
         var appConfig = CreateAppConfig();
+        var step = CreateActionStep(httpVerb: HttpVerbs.PATCH);
         const string payload = "<env><action>CHANGE</action><userId>user-upd-001</userId></env>";
         var resource = new Core2EnterpriseUser { Identifier = "user-upd-001" };
 
-        await sut.UpdateAsync(payload, resource, appConfig, "corr-t19");
+        await sut.UpdateAsync(payload, resource, "eagle-app", appConfig, step, "corr-t19");
 
         Assert.Contains("<action>CHANGE</action>", handler.LastRequestBody);
     }
@@ -453,18 +433,15 @@ public class EagleSOAPIntegrationTests
     public async Task MapAndPreparePayloadAsync_OriginalTemplateNotMutated_AfterCall()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates:
-            [
-                new("<env><correlationId>{{CorrelationId}}</correlationId></env>", SOAPActions.Create)
-            ]);
-        var originalTemplate = appConfig.SOAPTemplates!.First().Template;
+        const string originalTemplate = "<env><correlationId>{{CorrelationId}}</correlationId></env>";
+        var step = CreateActionStep(template: originalTemplate);
+        var appConfig = CreateAppConfig();
 
         await sut.MapAndPreparePayloadAsync(
-            [], new Core2EnterpriseUser(), appConfig);
+            [], new Core2EnterpriseUser(), appConfig, step);
 
-        Assert.Equal(originalTemplate, appConfig.SOAPTemplates!.First().Template);
-        Assert.Contains("{{CorrelationId}}", appConfig.SOAPTemplates!.First().Template);
+        Assert.Equal(originalTemplate, step.Template);
+        Assert.Contains("{{CorrelationId}}", step.Template);
     }
 
     #endregion
@@ -698,7 +675,6 @@ public class EagleSOAPIntegrationTests
     }
 
     private static AppConfig CreateAppConfig(
-        ICollection<SOAPTemplate>? templates = null,
         ICollection<AttributeSchema>? schema = null,
         AuthenticationMethods authMethodOutbound = AuthenticationMethods.None,
         dynamic? authDetails = null,
@@ -724,7 +700,6 @@ public class EagleSOAPIntegrationTests
                     Get     = new Uri("https://eagle.test/eagle/v2/users")
                 }
             ],
-            SOAPTemplates = templates ?? DefaultSOAPTemplates(),
             AuthenticationFlow = authenticationFlow
         };
     }
@@ -745,6 +720,7 @@ public class EagleSOAPIntegrationTests
     private static ActionStep CreateActionStep(
         string endpoint = "https://eagle.test/EagleMLWebService20",
         HttpVerbs httpVerb = HttpVerbs.POST,
+        string? template = null,
         ICollection<AttributeSchema>? attributes = null)
     {
         return new ActionStep
@@ -753,16 +729,10 @@ public class EagleSOAPIntegrationTests
             HttpVerb = httpVerb,
             StepOrder = 1,
             IsMandatory = true,
+            Template = template,
             UserAttributeSchemas = attributes
         };
     }
-
-    private static List<SOAPTemplate> DefaultSOAPTemplates() =>
-    [
-        new("<env><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId></env>", SOAPActions.Create),
-        new("<env><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId></env>", SOAPActions.Update),
-        new("<env><correlationId>{{CorrelationId}}</correlationId><userId>{{Identifier}}</userId></env>", SOAPActions.Delete)
-    ];
 
     private static string EagleAckXml(bool isNegative, string correlationId) =>
         $"""

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/EagleInvestment/EagleSOAPIntegrationTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/EagleInvestment/EagleSOAPIntegrationTests.cs
@@ -336,6 +336,37 @@ public class EagleSOAPIntegrationTests
     }
 
     [Fact]
+    public async Task DeleteAsync_WhenEmptyAttributesOnStep_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            httpVerb: HttpVerbs.DELETE,
+            template: "<env><userId>{{Identifier}}</userId></env>",
+            attributes: new List<AttributeSchema>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.DeleteAsync("user-001", "eagle-app", appConfig, step, "corr-del-guard-2"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenIdentifierMappingMissingOnStep_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            httpVerb: HttpVerbs.DELETE,
+            template: "<env><email>{{Email}}</email></env>",
+            attributes:
+            [
+                new() { DestinationField = "Email", SourceValue = "UserName", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
+            ]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.DeleteAsync("user-001", "eagle-app", appConfig, step, "corr-del-guard-3"));
+    }
+
+    [Fact]
     public async Task DeleteAsync_EmlBodyContainsActionDelete_FromTemplate()
     {
         var handler = new TestHttpMessageHandler(_ =>

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
@@ -30,13 +30,14 @@ public class SOAPIntegrationUnitTests
     }
 
     [Fact]
-    public async Task MapAndPreparePayloadAsync_WithAppConfigAndNoTemplate_ThrowsInvalidOperationException()
+    public async Task MapAndPreparePayloadAsync_WithActionStepAndNoTemplate_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(templates: null);
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(template: null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.MapAndPreparePayloadAsync(new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig));
+            sut.MapAndPreparePayloadAsync(new List<AttributeSchema>(), new Core2EnterpriseUser(), appConfig, step));
     }
 
     [Fact]
@@ -49,15 +50,13 @@ public class SOAPIntegrationUnitTests
             new() { DestinationField = "UserName", SourceValue = "UserName", MappingType = MappingTypes.Direct }
         };
 
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<Envelope><Identifier>{{Identifier}}</Identifier><UserName>{{UserName}}</UserName></Envelope>", SOAPActions.Create)
-            });
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            template: "<Envelope><Identifier>{{Identifier}}</Identifier><UserName>{{UserName}}</UserName></Envelope>");
 
         var resource = new Core2EnterpriseUser { Identifier = "ID-123", UserName = "soap.user" };
 
-        var payload = await sut.MapAndPreparePayloadAsync(schema, resource, appConfig);
+        var payload = await sut.MapAndPreparePayloadAsync(schema, resource, appConfig, step);
 
         string payloadText = Assert.IsType<string>(payload);
         Assert.Contains("<Identifier>ID-123</Identifier>", payloadText);
@@ -149,17 +148,17 @@ public class SOAPIntegrationUnitTests
     }
 
     [Fact]
-    public async Task GetAsync_WhenTemplateMissingForGet_ThrowsInvalidOperationException()
+    public async Task GetAsync_WhenTemplateMissingOnStep_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<Delete>{{Identifier}}</Delete>", SOAPActions.Delete)
-            });
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/users/get",
+            httpVerb: HttpVerbs.GET,
+            template: null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.GetAsync("U-100", appConfig, "corr-1"));
+            sut.GetAsync("U-100", appConfig, step, "corr-1"));
     }
 
     [Fact]
@@ -182,12 +181,12 @@ public class SOAPIntegrationUnitTests
             });
 
         var sut = CreateSut(handler);
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>", SOAPActions.Get)
-            },
-            schema: new List<AttributeSchema>
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/users/get",
+            httpVerb: HttpVerbs.GET,
+            template: "<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>",
+            attributes: new List<AttributeSchema>
             {
                 new()
                 {
@@ -198,7 +197,7 @@ public class SOAPIntegrationUnitTests
                 }
             });
 
-        var result = await sut.GetAsync("U-555", appConfig, "corr-2");
+        var result = await sut.GetAsync("U-555", appConfig, step, "corr-2");
 
         Assert.Equal("U-555", result.Identifier);
         Assert.Equal("test.soap", result.UserName);
@@ -207,17 +206,21 @@ public class SOAPIntegrationUnitTests
     }
 
     [Fact]
-    public async Task DeleteAsync_WhenTemplateMissingForDelete_ThrowsInvalidOperationException()
+    public async Task DeleteAsync_WhenTemplateMissingOnStep_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/users/delete",
+            httpVerb: HttpVerbs.DELETE,
+            template: null,
+            attributes: new List<AttributeSchema>
             {
-                new("<GetUser/>", SOAPActions.Get)
+                new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
             });
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.DeleteAsync("U-777", appConfig, "corr-3"));
+            sut.DeleteAsync("U-777", "soap-app", appConfig, step, "corr-3"));
     }
 
     [Fact]
@@ -239,12 +242,12 @@ public class SOAPIntegrationUnitTests
             });
 
         var sut = CreateSut(handler);
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>", SOAPActions.Delete)
-            },
-            schema: new List<AttributeSchema>
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/users/delete",
+            httpVerb: HttpVerbs.DELETE,
+            template: "<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>",
+            attributes: new List<AttributeSchema>
             {
                 new()
                 {
@@ -256,7 +259,7 @@ public class SOAPIntegrationUnitTests
             });
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
-            sut.DeleteAsync("U-777", appConfig, "corr-4"));
+            sut.DeleteAsync("U-777", "soap-app", appConfig, step, "corr-4"));
     }
 
     [Fact]
@@ -721,14 +724,11 @@ public class SOAPIntegrationUnitTests
     public async Task GetAsyncV2_WithNoAttributesOnStep_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>", SOAPActions.Get)
-            });
+        var appConfig = CreateAppConfig();
         var step = CreateActionStep(
             endpoint: "https://soap.example.test/v2/users/get",
             httpVerb: HttpVerbs.GET,
+            template: "<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>",
             attributes: null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -758,14 +758,11 @@ public class SOAPIntegrationUnitTests
         {
             new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.GET }
         };
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>", SOAPActions.Get)
-            });
+        var appConfig = CreateAppConfig();
         var step = CreateActionStep(
             endpoint: "https://soap.example.test/v2/users/get",
             httpVerb: HttpVerbs.GET,
+            template: "<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>",
             attributes: stepAttributes);
 
         var result = await sut.GetAsync("V2-GET-1", appConfig, step, "corr-v2-7");
@@ -866,14 +863,11 @@ public class SOAPIntegrationUnitTests
     public async Task DeleteAsyncV2_WithMissingTemplate_ThrowsInvalidOperationException()
     {
         var sut = CreateSut();
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<GetUser/>", SOAPActions.Get)
-            });
+        var appConfig = CreateAppConfig();
         var step = CreateActionStep(
             endpoint: "https://soap.example.test/v2/users/delete",
             httpVerb: HttpVerbs.DELETE,
+            template: null,
             attributes: new List<AttributeSchema>
             {
                 new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
@@ -897,14 +891,11 @@ public class SOAPIntegrationUnitTests
             });
 
         var sut = CreateSut(handler);
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>", SOAPActions.Delete)
-            });
+        var appConfig = CreateAppConfig();
         var step = CreateActionStep(
             endpoint: "https://soap.example.test/v2/users/delete",
             httpVerb: HttpVerbs.DELETE,
+            template: "<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>",
             attributes: new List<AttributeSchema>
             {
                 new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
@@ -932,14 +923,11 @@ public class SOAPIntegrationUnitTests
             });
 
         var sut = CreateSut(handler);
-        var appConfig = CreateAppConfig(
-            templates: new List<SOAPTemplate>
-            {
-                new("<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>", SOAPActions.Delete)
-            });
+        var appConfig = CreateAppConfig();
         var step = CreateActionStep(
             endpoint: "https://soap.example.test/v2/users/delete",
             httpVerb: HttpVerbs.DELETE,
+            template: "<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>",
             attributes: new List<AttributeSchema>
             {
                 new() { DestinationField = "Identifier", SourceValue = "Identifier", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
@@ -954,6 +942,7 @@ public class SOAPIntegrationUnitTests
     private static ActionStep CreateActionStep(
         string endpoint = "https://soap.example.test/v2/action",
         HttpVerbs httpVerb = HttpVerbs.POST,
+        string? template = null,
         ICollection<AttributeSchema>? attributes = null)
     {
         return new ActionStep
@@ -962,6 +951,7 @@ public class SOAPIntegrationUnitTests
             HttpVerb = httpVerb,
             StepOrder = 1,
             IsMandatory = true,
+            Template = template,
             UserAttributeSchemas = attributes
         };
     }
@@ -1002,7 +992,7 @@ public class SOAPIntegrationUnitTests
             loggerMock.Object);
     }
 
-    private static AppConfig CreateAppConfig(ICollection<SOAPTemplate>? templates = null,
+    private static AppConfig CreateAppConfig(
         ICollection<AttributeSchema>? schema = null,
         AuthenticationMethods authMethodOutbound = AuthenticationMethods.None,
         dynamic? authDetails = null,
@@ -1028,7 +1018,6 @@ public class SOAPIntegrationUnitTests
                     Delete = new Uri("https://soap.example.test/users/delete")
                 }
             },
-            SOAPTemplates = templates,
             AuthenticationFlow = authenticationFlow
         };
     }

--- a/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
+++ b/KN.KloudIdentity.MapperTests/SOAPIntegration/SOAPIntegrationUnitTests.cs
@@ -736,6 +736,39 @@ public class SOAPIntegrationUnitTests
     }
 
     [Fact]
+    public async Task GetAsyncV2_WithEmptyAttributesOnStep_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/v2/users/get",
+            httpVerb: HttpVerbs.GET,
+            template: "<GetUser><Identifier>{{Identifier}}</Identifier></GetUser>",
+            attributes: new List<AttributeSchema>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetAsync("U-1", appConfig, step, "corr-v2-6b"));
+    }
+
+    [Fact]
+    public async Task GetAsyncV2_WithMissingIdentifierMapping_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/v2/users/get",
+            httpVerb: HttpVerbs.GET,
+            template: "<GetUser><Email>{{Email}}</Email></GetUser>",
+            attributes: new List<AttributeSchema>
+            {
+                new() { DestinationField = "Email", SourceValue = "UserName", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.GET }
+            });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetAsync("U-1", appConfig, step, "corr-v2-6c"));
+    }
+
+    [Fact]
     public async Task GetAsyncV2_WithValidStepAndTemplate_ReturnsMappedUser()
     {
         var handler = new TestHttpMessageHandler(_ =>
@@ -875,6 +908,39 @@ public class SOAPIntegrationUnitTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             sut.DeleteAsync("U-1", "soap-app", appConfig, step, "corr-v2-14"));
+    }
+
+    [Fact]
+    public async Task DeleteAsyncV2_WithEmptyAttributesOnStep_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/v2/users/delete",
+            httpVerb: HttpVerbs.DELETE,
+            template: "<DeleteUser><Identifier>{{Identifier}}</Identifier></DeleteUser>",
+            attributes: new List<AttributeSchema>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.DeleteAsync("U-1", "soap-app", appConfig, step, "corr-v2-14b"));
+    }
+
+    [Fact]
+    public async Task DeleteAsyncV2_WithMissingIdentifierMapping_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        var appConfig = CreateAppConfig();
+        var step = CreateActionStep(
+            endpoint: "https://soap.example.test/v2/users/delete",
+            httpVerb: HttpVerbs.DELETE,
+            template: "<DeleteUser><Email>{{Email}}</Email></DeleteUser>",
+            attributes: new List<AttributeSchema>
+            {
+                new() { DestinationField = "Email", SourceValue = "UserName", MappingType = MappingTypes.Direct, HttpRequestType = HttpRequestTypes.DELETE }
+            });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.DeleteAsync("U-1", "soap-app", appConfig, step, "corr-v2-14c"));
     }
 
     [Fact]


### PR DESCRIPTION
This pull request implements a significant refactor of how SOAP XML templates are managed and accessed throughout the codebase. Instead of storing SOAP templates globally in `AppConfig.SOAPTemplates`, each `ActionStep` now directly contains its own `template` property. This change simplifies the configuration, eliminates the need for several helper methods and types, and updates all related integration logic and tests to use the new structure.

The most important changes are:

**Domain Model and Configuration Refactor**
- Added a nullable `Template` property to the `ActionStep` class, so each step can now directly hold its SOAP XML template. (`KN.KloudIdentity.Mapper.Domain/Application/ActionStep.cs`)
- Removed the `SOAPTemplates` property from `AppConfig` and deleted the now-unused types `SOAPTemplate` and `SOAPActions`. (`KN.KloudIdentity.Mapper.Domain/Application/AppConfig.cs`, `KN.KloudIdentity.Mapper.Domain/Application/SOAPTemplate.cs`, `KN.KloudIdentity.Mapper.Domain/Mapping/SOAPActions.cs`) [[1]](diffhunk://#diff-78816b67115b08a219936fab732f3b11f5e79aa1715183707cdd85109368f5ebL48) [[2]](diffhunk://#diff-b97cd2cfa7a3cb5900336862b12656023034a77864efe8e39d7d48679f274c15L1-L8) [[3]](diffhunk://#diff-8b05700d7cb3efb11040d9860f89933cbd31a900021e8d9c346df4ddd90a216cL1-L9)

**Integration Logic Updates**
- Refactored all SOAP integration logic to access templates via `actionStep.Template` instead of looking them up in `AppConfig.SOAPTemplates`. This includes updating all relevant overloads in `SOAPIntegration` and `EagleSOAPIntegration`, and removing/deprecating old helper methods such as `ResolveSoapTemplate` and `MapHttpVerbToSoapAction`. (`KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/EagleSOAPIntegration.cs`) [[1]](diffhunk://#diff-327c40f59c84a0211a94368647b983eaea3c82ecdf3f40b8b0a4011e08fd7c1aR45-R53) [[2]](diffhunk://#diff-327c40f59c84a0211a94368647b983eaea3c82ecdf3f40b8b0a4011e08fd7c1aL93-R98) [[3]](diffhunk://#diff-327c40f59c84a0211a94368647b983eaea3c82ecdf3f40b8b0a4011e08fd7c1aL125-R126) [[4]](diffhunk://#diff-327c40f59c84a0211a94368647b983eaea3c82ecdf3f40b8b0a4011e08fd7c1aL154-R149) [[5]](diffhunk://#diff-327c40f59c84a0211a94368647b983eaea3c82ecdf3f40b8b0a4011e08fd7c1aL190-R169)

**Interface and Method Overloads**
- Introduced a new overload of `MapAndPreparePayloadAsync` that takes an `ActionStep` parameter, and updated the interface (`IIntegrationBase`) accordingly. The old overload is now deprecated for SOAP and throws a `NotSupportedException` if used in that context. (`KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/IIntegrationBase.cs`)

**Test and Dead Code Cleanup**
- Updated all tests to remove references to `SOAPTemplates` and instead set the `Template` property on the relevant `ActionStep`. Deleted obsolete files and confirmed there are no remaining references to the old types. [[1]](diffhunk://#diff-b97cd2cfa7a3cb5900336862b12656023034a77864efe8e39d7d48679f274c15L1-L8) [[2]](diffhunk://#diff-8b05700d7cb3efb11040d9860f89933cbd31a900021e8d9c346df4ddd90a216cL1-L9)

**Migration Guidance**
- Provided a detailed step-by-step migration plan and execution order in `.github/prompts/plan-soapintegration-changes-with-new-appconfig.md` to ensure safe and incremental adoption of the new structure.