### PR TITLE
Refactor AS400 integration and add tenantId parameter

### DIFF
--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IListAs400GroupsQuery.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Abstractions/IListAs400GroupsQuery.cs
@@ -4,5 +4,5 @@ namespace KN.KloudIdentity.Mapper.Infrastructure.ExternalAPICalls.Abstractions;
 
 public interface IListAs400GroupsQuery
 {
-    Task<IList<As400Group>> ListAsync(string appId, CancellationToken cancellationToken = default);
+    Task<IList<As400Group>> ListAsync(string appId, string tenantId, CancellationToken cancellationToken = default);
 }

--- a/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Queries/ListAs400GroupsQuery.cs
+++ b/KN.KloudIdentity.Mapper.Infrastructure/ExternalAPICalls/Queries/ListAs400GroupsQuery.cs
@@ -20,20 +20,26 @@ public class ListAs400GroupsQuery : IListAs400GroupsQuery
         _requestClient = serviceScope.ServiceProvider.GetRequiredService<IRequestClient<IMetaverseServiceRequestMsg>>();
     }
 
-    public async Task<IList<As400Group>> ListAsync(string appId, CancellationToken cancellationToken = default)
+    public async Task<IList<As400Group>> ListAsync(string appId, string tenantId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(appId))
         {
             throw new ArgumentNullException(nameof(appId));
         }
 
-        return await SendMessageAndProcessResponse(appId);
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentNullException(nameof(tenantId));
+        }
+
+        return await SendMessageAndProcessResponse(appId, tenantId);
     }
 
-    private async Task<IList<As400Group>> SendMessageAndProcessResponse(string appId)
+    private async Task<IList<As400Group>> SendMessageAndProcessResponse(string appId, string tenantId)
     {
+        var payload = JsonConvert.SerializeObject(new { AppId = appId, TenantId = tenantId });
         var message = new MetaverseServiceRequestMsg(
-            appId,
+            payload,
             ActionType.ListAs400Groups.ToString(),
             Guid.NewGuid().ToString(),
             null

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/AS400Integration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/AS400Integration.cs
@@ -23,7 +23,7 @@ public class AS400Integration(
     IReqStagQueuePublisher reqStagQueuePublisher,
     IOptions<AppSettings> appSettings,
     IListAs400GroupsQuery listAs400GroupsQuery)
-    : IIntegrationBase
+    : IIntegrationBaseV2
 {
     public IntegrationMethods IntegrationMethod { get; init; } = IntegrationMethods.AS400;
 
@@ -299,7 +299,7 @@ public class AS400Integration(
     {
         var groups = string.IsNullOrEmpty(payload["groupProfile"])
             ? []
-            : (List<As400Group>)await listAs400GroupsQuery.ListAsync(appConfig.AppId, cancellationToken);
+            : (List<As400Group>)await listAs400GroupsQuery.ListAsync(appConfig.AppId, appConfig.TenantId, cancellationToken);
 
         ValidateUsername(payload["username"]);
         ValidateUserClass(payload["userClass"]);
@@ -412,4 +412,38 @@ public class AS400Integration(
     {
         return basePath.TrimEnd('/') + endpoint;
     }
+
+    #region Not Implemented: Action-based methods (not required for AS400 integration)
+
+    public Task<Core2EnterpriseUser?> ProvisionAsync(dynamic payload, string appId, AppConfig appConfig,
+        ActionStep actionStep, string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based provisioning is not supported for AS400 integration.");
+    }
+
+    public Task<Core2EnterpriseUser> GetAsync(string identifier, AppConfig appConfig, ActionStep actionStep,
+        string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based retrieval is not supported for AS400 integration.");
+    }
+
+    public Task<Core2EnterpriseUser> ReplaceAsync(dynamic payload, Core2EnterpriseUser resource, string appId,
+        AppConfig appConfig, ActionStep actionStep, string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based replacement is not supported for AS400 integration.");
+    }
+
+    public Task UpdateAsync(dynamic payload, Core2EnterpriseUser resource, string appId, AppConfig appConfig,
+        ActionStep actionStep, string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based update is not supported for AS400 integration.");
+    }
+
+    public Task DeleteAsync(string identifier, string appId, AppConfig appConfig, ActionStep actionStep,
+        string correlationId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("Action-based deletion is not supported for AS400 integration.");
+    }
+
+    #endregion
 }

--- a/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
+++ b/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
@@ -80,7 +80,7 @@ public static class ServiceExtension
 
         services.AddScoped<IIntegrationBase, RESTIntegration>();
         services.AddScoped<IIntegrationBase, LinuxIntegration>();
-        services.AddScoped<IIntegrationBase, AS400Integration>();
+        services.AddScoped<IIntegrationBaseV2, AS400Integration>();
         services.AddScoped<IIntegrationBase, SQLIntegration>();
         services.AddScoped<IIntegrationBaseV2, SOAPIntegration>();
         services.AddScoped<IIntegrationBaseV2, EagleSOAPIntegration>();


### PR DESCRIPTION
This pull request introduces several important changes to support multi-tenancy and clarify integration method contracts, particularly for the AS400 integration. The most significant updates include requiring a `tenantId` parameter for AS400 group queries, updating interfaces and implementations accordingly, and explicitly marking unsupported action-based methods in the AS400 integration.

**Multi-tenancy support for AS400 group queries:**
- The `IListAs400GroupsQuery` interface and its implementation were updated to require a `tenantId` parameter in addition to `appId` when listing AS400 groups, ensuring queries are tenant-aware. [[1]](diffhunk://#diff-bfff979ff4d48e517d4483c82630d9c0711c9950a6f17af95742c2d4c4b88ba6L7-R7) [[2]](diffhunk://#diff-a6368ab37d66b02d76e2ffc0967987229fd50f4cf57d4998c610b30d4254f67aL23-R42) [[3]](diffhunk://#diff-cf0d4d0421d67bdcb6f6d9e99fc45ba1de4f704326d8b94a7a2aa006bae4f2b6L302-R302)

**AS400 integration contract and registration updates:**
- The `AS400Integration` class now implements `IIntegrationBaseV2` instead of `IIntegrationBase`, and its DI registration was updated to match. [[1]](diffhunk://#diff-cf0d4d0421d67bdcb6f6d9e99fc45ba1de4f704326d8b94a7a2aa006bae4f2b6L26-R26) [[2]](diffhunk://#diff-eb5b6bd6eb2859b8b91e6e3f07f69a42540f5789a433852a148ac92b63fc8281L83-R83)
- Action-based methods (`ProvisionAsync`, `GetAsync`, `ReplaceAsync`, `UpdateAsync`, `DeleteAsync`) were explicitly added to `AS400Integration` and throw `NotImplementedException`, clarifying that these operations are not supported for AS400.