### PR TITLE
Enhance Tungsten AP Essentials integration with user management features

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs cat)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(xargs cat)"
+      "Bash(xargs cat)",
+      "Bash(python3 -c \"import sys,json; data=json.load\\(sys.stdin\\); [print\\(json.dumps\\(i,indent=2\\)\\) for i in data if i.get\\('AppId'\\)=='tungstenapessentials']\")"
     ]
   }
 }

--- a/.github/prompts/plan-118-tungsten-ap-essentials-integration.md
+++ b/.github/prompts/plan-118-tungsten-ap-essentials-integration.md
@@ -153,11 +153,19 @@ static ConcurrentDictionary<string, (string Token, DateTime ExpiresAt)>
 2. Set `Authorization: ApsToken Value="<token>"`
 3. Apply custom headers from `AppSettings.AppIntegrationConfigs` via `SetCustomHeaders`
 
-#### `ProvisionAsync` override
+#### `ProvisionAsync` override (upsert pattern)
 1. Get `OrganizationId` from `AppIntegrationConfigs[appId].OrganizationId`
-2. Build `User2` payload — `OrganizationId` merged into mapped payload
-3. POST to `UserURIs[0].Post`
-4. Parse response → `Identifier = response["UserName"]`
+2. Build payload — `OrganizationId` merged into mapped payload
+3. Extract `UserName` from payload (required before GET)
+4. **GET** `/users/rest/single/{orgId}/{userName}`:
+   - `404 NotFoundException` → user does not exist → proceed to **POST** (create)
+   - `200` → user already exists in Tungsten → call **`ReplaceAsync`** (update) and return existing `UserName`
+5. POST to `UserURIs[0].Post` (only reached if user was not found)
+6. Parse response → `Identifier = response["UserName"]`
+
+> **Why upsert?** If a user already exists in Tungsten with the same `UserName` (pre-existing or manually created),
+> a blind POST returns a conflict error and Entra provisioning gets stuck retrying. GET-first is idempotent and
+> handles re-runs safely without depending on Tungsten's conflict error code.
 
 #### `GetAsync` override
 1. Get `OrganizationId` from `AppIntegrationConfigs[appId].OrganizationId`
@@ -249,7 +257,8 @@ services.AddScoped<IIntegrationBase, TungstenAPEssentialsIntegration>();
 | `IsActive: true` silently ignored on create | New users stay inactive until logon email sent |
 | `x-rs-key` is region-specific | AU key returns `401 Invalid API key` against other regions |
 | DELETE returns `200` with full entity | Not `204` — parse body for audit log |
-| GET non-existent user returns `404` | Use as "safe to create" signal |
+| GET non-existent user returns `404` | Used as "safe to create" signal in upsert flow |
+| POST with existing `UserName` causes conflict | Use GET-first upsert: 404 → POST, 200 → PUT |
 
 ---
 

--- a/.github/prompts/plan-118-tungsten-ap-essentials-integration.md
+++ b/.github/prompts/plan-118-tungsten-ap-essentials-integration.md
@@ -1,0 +1,261 @@
+# Plan 118 — Tungsten AP Essentials Integration
+
+**Branch:** `app/tungstenapessentials`
+**Date:** 2026-06-15
+**Author:** Ariful Islam
+**API Doc:** `thaiunion-au-user-provisioning-guide.html` (AU tenant, verified 2026-06-12)
+
+---
+
+## Overview
+
+Integrate Tungsten AP Essentials (ReadSoft Online) into KloudIdentity as a new integration method.
+Tungsten uses a cookieless token auth flow — credentials (username/password) are exchanged for a
+short-lived `ApsToken`. All API calls carry `Authorization: ApsToken Value="<token>"`.
+
+UI configuration: `AuthenticationMethodOutbound = Basic` — no new auth strategy needed.
+Credentials are read from `AuthenticationDetails` as `BasicAuthentication`.
+
+---
+
+## Base URL & Required Headers
+
+```
+Base URL:  https://services-au.readsoftonline.com
+Auth URL:  {BaseUrl}/authentication/rest/authenticate
+
+Fixed headers on every call:
+  Content-Type:    application/json
+  Accept:          application/json        ← required, else API returns XML
+  x-rs-key:        <API_KEY>               ← from Azure App Config / Key Vault
+  x-rs-version:    2011-10-14
+  x-rs-culture:    en-US
+  x-rs-uiculture:  en-US
+```
+
+> `x-rs-key` and fixed headers are stored in `AppSettings.AppIntegrationConfigs[appId].HttpSettings.Headers`
+> (value resolved from Azure Key Vault via App Config reference).
+> Applied automatically by `SetCustomHeaders` in `CreateHttpClientAsync`.
+
+---
+
+## Auth Flow
+
+```
+POST {BaseUrl}/authentication/rest/authenticate
+Body: { "UserName": "...", "Password": "...", "AuthenticationType": 4 }
+
+Response: { "Status": 1, "Token": "<aps_token>" }
+
+All API calls: Authorization: ApsToken Value="<aps_token>"
+```
+
+Token validity: **30 minutes**. Cache window: **20 minutes** (safe margin).
+
+---
+
+## API Endpoints (verified against AU tenant)
+
+| Operation | Verb   | Path                                              | Identifier used     |
+|-----------|--------|---------------------------------------------------|---------------------|
+| Create    | POST   | `/users/rest`                                     | —                   |
+| Get       | GET    | `/users/rest/single/{0}/{1}`                      | `{0}` = orgId, `{1}` = **UserName** |
+| Update    | PUT    | `/users/rest`                                     | **Id** (in body)    |
+| Delete    | DELETE | `/users/rest/{0}`                                 | `{0}` = **Id** (GUID) |
+
+### Identifier strategy
+
+- `ProvisionAsync` → POST → parse `UserName` from response → return as `core2User.Identifier`
+- `GetAsync` → `identifier` = UserName → `string.Format(getUri, organizationId, identifier)`
+- `ReplaceAsync` / `UpdateAsync` → call `GetAsync` to resolve Tungsten `Id` → PUT with `Id` in body
+- `DeleteAsync` → call `GetAsync` to resolve Tungsten `Id` → `string.Format(deleteUri, id)`
+
+> **Why UserName as SCIM identifier?** The only GET endpoint is keyed by UserName
+> (`/single/{orgId}/{userName}`). No GET-by-Id endpoint exists. Update and Delete need the
+> GUID `Id` — resolved via `GetAsync` before each write operation.
+
+### Minimum Create payload (verified)
+
+```json
+{
+  "OrganizationId": "292d2d9924dd4ea0b5399d2ec8b0207b",
+  "UserName": "john.smith",
+  "FullName": "John Smith",
+  "EmailAddress": "john.smith@example.com",
+  "IsActive": true,
+  "UseIdentityProvider": false
+}
+```
+
+> Do NOT include `MonetaryLimit: { Value: 0 }` — causes `400` ("must specify a manager").
+> `IsActive` is always `false` on creation until user completes login setup — expected behavior.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Add `OrganizationId` to `AppIntegrationConfig`
+
+**File:** `KN.KloudIdentity.Mapper.Domain/AppSettings.cs`
+
+```csharp
+public class AppIntegrationConfig
+{
+    public string AppId { get; set; } = string.Empty;
+    public HttpSettings? HttpSettings { get; set; }
+    public string ClientType { get; set; } = string.Empty;
+    public string? OrganizationId { get; set; }   // ← add this
+}
+```
+
+Read in integration code:
+```csharp
+var config = _appSettings.AppIntegrationConfigs.FirstOrDefault(x => x.AppId == appConfig.AppId)
+    ?? throw new InvalidOperationException($"AppIntegrationConfig not found for appId: {appConfig.AppId}");
+
+var organizationId = config.OrganizationId
+    ?? throw new InvalidOperationException($"OrganizationId not configured for appId: {appConfig.AppId}");
+```
+
+---
+
+### Step 2 — Create `TungstenAPEssentialsIntegration` class
+
+**File:** `KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs`
+
+Extends `RESTIntegration`. Overrides:
+
+#### `IntegrationMethod` property
+```csharp
+IntegrationMethod = IntegrationMethods.REST;  // Tungsten is a REST app — factory resolves by AppIdToIntegration
+```
+
+#### Token cache (static — survives DI scopes since class is Scoped)
+```
+static ConcurrentDictionary<string, (string Token, DateTime ExpiresAt)>
+  keyed by appId
+  hit:  ExpiresAt > UtcNow  →  return cached token
+  miss: POST authenticate, store with UtcNow.AddMinutes(20), return token
+  401:  evict entry, re-authenticate once, retry
+```
+
+#### `GetAuthenticationAsync` override
+1. Deserialize `config.AuthenticationDetails` → `BasicAuthentication` (Username, Password)
+2. Validate both fields present
+3. Check token cache — return if still valid
+4. Apply custom headers (x-rs-key etc.) from `AppIntegrationConfigs` to the auth HTTP client
+5. POST `{ UserName, Password, AuthenticationType: 4 }` to `{BaseUrl}/authentication/rest/authenticate`
+6. Parse `Token` from JSON response body
+7. Cache with 20-min expiry, return token
+
+#### `CreateHttpClientAsync` override (protected)
+1. Get token via `GetAuthenticationAsync`
+2. Set `Authorization: ApsToken Value="<token>"`
+3. Apply custom headers from `AppSettings.AppIntegrationConfigs` via `SetCustomHeaders`
+
+#### `ProvisionAsync` override
+1. Get `OrganizationId` from `AppIntegrationConfigs[appId].OrganizationId`
+2. Build `User2` payload — `OrganizationId` merged into mapped payload
+3. POST to `UserURIs[0].Post`
+4. Parse response → `Identifier = response["UserName"]`
+
+#### `GetAsync` override
+1. Get `OrganizationId` from `AppIntegrationConfigs[appId].OrganizationId`
+2. URL: `string.Format(userUri.Get.ToString(), organizationId, identifier)`
+   → `/users/rest/single/{orgId}/{userName}`
+3. Parse response → return `Core2EnterpriseUser { Identifier = userName, ExternalId = response["Id"] }`
+   (ExternalId holds the Tungsten GUID `Id` for use by Replace/Delete)
+
+#### `ReplaceAsync` / `UpdateAsync` override
+1. Get `OrganizationId` from `AppIntegrationConfigs`
+2. Call `GetAsync(resource.Identifier)` → get `ExternalId` (Tungsten GUID `Id`)
+3. Build `User2` body with both `OrganizationId` and `Id`
+4. PUT to `UserURIs[0].Put`
+
+#### `DeleteAsync` override
+1. Call `GetAsync(identifier)` → get `ExternalId` (Tungsten GUID `Id`)
+2. URL: `string.Format(userUri.Delete.ToString(), externalId)`
+   → `/users/rest/{id}`
+3. DELETE
+
+---
+
+### Step 4 — Register in DI
+
+**File:** `KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs`
+
+```csharp
+services.AddScoped<IIntegrationBase, TungstenAPEssentialsIntegration>();
+```
+
+---
+
+### Step 5 — Wire up in configuration
+
+**File:** Azure App Configuration (`KI:AppIntegrationConfigs` key, per-environment label)
+
+```json
+[
+  {
+    "AppId": "<tungsten-appId>",
+    "OrganizationId": "292d2d9924dd4ea0b5399d2ec8b0207b",
+    "HttpSettings": {
+      "Headers": {
+        "x-rs-key": "@Microsoft.KeyVault(SecretUri=https://<vault>.vault.azure.net/secrets/TungstenApiKey/)",
+        "x-rs-version": "2011-10-14",
+        "x-rs-culture": "en-US",
+        "x-rs-uiculture": "en-US"
+      }
+    }
+  }
+]
+```
+
+**File:** `Microsoft.SCIM.WebHostSample/appsettings.json`
+
+```json
+"IntegrationMappings": {
+  "AppIdToIntegration": {
+    "<tungsten-appId>": "TungstenAPEssentialsIntegration"
+  }
+}
+```
+
+**Azure Key Vault:** Add secret `TungstenApiKey` = actual `x-rs-key` GUID value.
+
+> `OrganizationId` is NOT a secret — stored as plain text in Azure App Config.
+> `x-rs-key` IS a secret — stored in Key Vault, referenced via `@Microsoft.KeyVault(...)`.
+> Both are resolved automatically at startup via the existing `ConfigureKeyVault` wiring in `Program.cs`.
+
+---
+
+## What is NOT needed
+
+- No new `IAuthStrategy` — auth logic lives entirely in the integration class override
+- No new `AuthenticationMethods` enum value — UI stays as `Basic (= 1)`
+- No new `IntegrationMethods` enum value — Tungsten is REST; factory resolves class via `AppIdToIntegration`
+- No EF migration — `IntegrationMethodOutbound = REST (1)` in DB, no schema change
+- No new domain model — `OrganizationId` added directly to existing `AppIntegrationConfig`
+
+---
+
+## Verified Gotchas (from API doc)
+
+| Gotcha | Detail |
+|--------|--------|
+| `AuthenticationType` must be int `4` | Sending string `"SetBodyToken"` returns `400` |
+| `Accept: application/json` required | Without it, API returns XML — must be on auth call too |
+| `MonetaryLimit: { Value: 0 }` causes `400` | Omit the field entirely |
+| `IsActive: true` silently ignored on create | New users stay inactive until logon email sent |
+| `x-rs-key` is region-specific | AU key returns `401 Invalid API key` against other regions |
+| DELETE returns `200` with full entity | Not `204` — parse body for audit log |
+| GET non-existent user returns `404` | Use as "safe to create" signal |
+
+---
+
+## Approach Rationale
+
+- Override approach (not `IAuthStrategy`) — `ApsToken Value="..."` header format is non-standard
+- `OrganizationId` in `AppIntegrationConfig` (Option A) — everything in one place in Azure App Config,
+  no management portal UI change needed, no new domain model
+- `x-rs-key` in Key Vault via App Config reference — follows existing secret management pattern

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Project Build
 
 on:
   push:
-    branches: ["main", "dev"]     
+    branches: ["main", "dev", "backup/master-1.0"]     
   pull_request:
-    branches: ["main", "dev"]
+    branches: ["main", "dev", "backup/master-1.0"]
 
 jobs:
   build-dotnet:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+KloudIdentity is a SCIM 2.0 provisioning service built on .NET 8. It connects Entra ID (Azure AD) to Line-of-Business applications using pluggable integration methods (REST, SQL, AS400, Linux, ITSM). MassTransit/RabbitMQ handles inter-service messaging; Hangfire handles background jobs; EF Core + SQL Server stores app configuration.
+
+## Commands
+
+```bash
+# Build
+dotnet build
+
+# Run (default port 5000)
+dotnet run --project Microsoft.SCIM.WebHostSample
+
+# Run DB migrations only then exit
+dotnet run --project Microsoft.SCIM.WebHostSample -- migrate
+
+# Add a new EF migration
+dotnet ef migrations add <Name> \
+  --project KN.KloudIdentity.Mapper.Infrastructure \
+  --startup-project Microsoft.SCIM.WebHostSample
+
+# Apply migrations manually
+dotnet ef database update \
+  --project KN.KloudIdentity.Mapper.Infrastructure \
+  --startup-project Microsoft.SCIM.WebHostSample
+
+# Run all tests
+dotnet test
+
+# Run a single test method
+dotnet test --filter "FullyQualifiedName~<ClassName>.<MethodName>"
+
+# Docker
+docker build -t scimconnector-api:latest -f ./dockerfile .
+```
+
+## Solution Structure
+
+| Project | Role |
+|---|---|
+| `Microsoft.SystemForCrossDomainIdentityManagement` | SCIM RFC 7644 protocol library (schemas, filtering, patch) |
+| `Microsoft.SCIM.WebHostSample` | ASP.NET Core host — controllers, middleware, DI wiring |
+| `KN.KloudIdentity.Mapper` | Core business logic — mapping engine, integration methods, auth strategies |
+| `KN.KloudIdentity.Mapper.Domain` | Shared domain models, enums, DTOs |
+| `KN.KloudIdentity.Mapper.Infrastructure` | EF Core DbContext (`KNContext`), repositories, `MetaverseIntegrationClient` |
+| `KN.KloudIdentity.MapperTests` | xUnit + Moq unit tests |
+
+## Key Architecture
+
+### Integration Method Pattern
+
+Every LOB integration implements `IIntegrationBaseV2` (`KN.KloudIdentity.Mapper/MapperCore/`). The interface covers the full SCIM lifecycle: `MapAndPreparePayloadAsync`, `GetAuthenticationAsync`, `ProvisionAsync`, `GetAsync`, `ReplaceAsync`, `UpdateAsync`, `DeleteAsync`, `ValidatePayloadAsync`.
+
+Current implementations in `MapperCore/IntegrationMethods/`:
+- `RESTIntegrationV4` — multi-step REST with action-based provisioning
+- `RESTIntegrationV2` / `RESTIntegration` — legacy REST
+- `SQLIntegration` — SQL Server direct
+- `AS400Integration` — IBM AS/400
+- `LinuxIntegration` — Linux system accounts
+- `ITSMIntegration` — ITSM via internal metaverse service (MassTransit, no direct auth)
+
+`IntegrationBaseFactory` selects the implementation at runtime from `AppConfig.IntegrationMethod`. App-to-integration mapping is also configurable in `appsettings.json` under `IntegrationMappings:AppIdToIntegration`.
+
+New integrations must be registered in `KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs`.
+
+### Payload Mapping
+
+`JSONParserUtilV2<T>.Parse(schema, resource)` converts a SCIM `Core2EnterpriseUser` into a `JObject` payload using `AttributeSchema` definitions. `DestinationField` uses **colon-separated** URN paths (`urn:kn:ki:schema:ExtendedProperties:ProjectKey`) — colons create nested JObject keys, dots do not.
+
+### Authentication Strategies
+
+`IAuthStrategy` implementations live in `MapperCore/Auth/`. Selected by `IAuthContext` based on `AppConfig.AuthenticationMethod`. Strategies: BasicAuth, OAuth2, ApiKey, DotRez (Navitaire-specific).
+
+### DI Registration
+
+All mapper services are registered in `ServiceExtension.cs::ConfigureMapperServices()`. Infrastructure services (EF, repositories, `MetaverseIntegrationClient`) are in `KN.KloudIdentity.Mapper.Infrastructure/DI/DependencyInjection.cs::AddInfrastructure()`. Both are called from `Startup.ConfigureServices`.
+
+### Messaging (MassTransit / RabbitMQ)
+
+- `IMetaverseIntegrationClient` → sends to `queue:metaverse_in` via `IRequestClient<IMetaverseServiceRequestMsg>` with a 60-second timeout
+- `IMgtPortalServiceRequestMsg` → sends to `queue:mgtportal_in`
+- `InterserviceConsumer` listens on `scimservice_in`
+- `AppConfigStartupSync` (hosted service) syncs app config from MgtPortal on startup
+- `IKloudIdentityLogger` also sends over MassTransit to the log aggregator service
+
+### EF Core
+
+`KNContext` is in `KN.KloudIdentity.Mapper.Infrastructure/Persistence/SQLServer/`. Migrations assembly is `KN.KloudIdentity.Mapper.Infrastructure`. Supports two SQL auth modes configured via `Database:AuthMode`: `"Sql"` (connection string) or `"Entra"` (token-based Azure SQL).
+
+### Logging
+
+Every operation-level event uses both Serilog (`Log.Information/Warning/Error`) for infrastructure tracing **and** `IKloudIdentityLogger.CreateLogAsync(CreateLogEntity)` for business audit logs. The `CreateLogEntity` constructor takes: `appId, logType, severity, eventInfo, logMessage, correlationId, loggerName, timestamp, user, null, null`.
+
+## Configuration
+
+Configuration is layered: `appsettings.json` → `appsettings.{env}.json` → User Secrets → Azure App Configuration (`KI:*` label) → Azure Key Vault. All app settings live under the `KI:` prefix. Required connection strings: `DefaultConnection` (SQL Server), `AppConfig` (Azure App Config), `HangfireDBConnection` (optional).

--- a/KN.KloudIdentity.Mapper.Domain/Shared/AppSettings.cs
+++ b/KN.KloudIdentity.Mapper.Domain/Shared/AppSettings.cs
@@ -55,6 +55,7 @@ public class AppIntegrationConfig
     public string AppId { get; set; } = string.Empty;
     public HttpSettings? HttpSettings { get; set; }
     public string ClientType { get; set; } = string.Empty;
+    public string? OrganizationId { get; set; }
 }   
 
 public class HttpSettings

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
@@ -82,8 +82,9 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
             client.SetCustomHeaders(customConfig.HttpSettings.Headers);
         }
 
-        // x-rs-key is resolved from App Config Key Vault reference — applied separately
-        client.DefaultRequestHeaders.Add("x-rs-key", GetApiKey());
+        // x-rs-key may already be present via HttpSettings.Headers; only fall back to KI:Tungsten:ApiKey when absent
+        if (!client.DefaultRequestHeaders.Contains("x-rs-key"))
+            client.DefaultRequestHeaders.Add("x-rs-key", GetApiKey());
 
         return client;
     }
@@ -361,8 +362,9 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
             client.SetCustomHeaders(customConfig.HttpSettings.Headers);
         }
 
-        // x-rs-key resolved from App Config Key Vault reference
-        client.DefaultRequestHeaders.Add("x-rs-key", GetApiKey());
+        // x-rs-key may already be present via HttpSettings.Headers; only fall back to KI:Tungsten:ApiKey when absent
+        if (!client.DefaultRequestHeaders.Contains("x-rs-key"))
+            client.DefaultRequestHeaders.Add("x-rs-key", GetApiKey());
 
         var response = await client.PostAsync(
             authUrl,

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
@@ -1,0 +1,368 @@
+//------------------------------------------------------------
+// Copyright (c) Kloudynet Technologies Sdn Bhd.  All rights reserved.
+//------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
+using KN.KI.LogAggregator.Library;
+using KN.KI.LogAggregator.Library.Abstractions;
+using KN.KloudIdentity.Mapper.Common;
+using KN.KloudIdentity.Mapper.Common.Exceptions;
+using KN.KloudIdentity.Mapper.Domain;
+using KN.KloudIdentity.Mapper.Domain.Application;
+using KN.KloudIdentity.Mapper.Domain.Authentication;
+using KN.KloudIdentity.Mapper.Domain.Mapping;
+using KN.KloudIdentity.Mapper.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.SCIM;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog;
+
+namespace KN.KloudIdentity.Mapper.MapperCore;
+
+public class TungstenAPEssentialsIntegration : RESTIntegration
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly AppSettings _appSettings;
+    private readonly IKloudIdentityLogger _logger;
+
+    private static readonly ConcurrentDictionary<string, (string Token, DateTime ExpiresAt)> _tokenCache = new();
+
+    public TungstenAPEssentialsIntegration(
+        IAuthContext authContext,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        IOptions<AppSettings> appSettings,
+        IKloudIdentityLogger logger)
+        : base(authContext, httpClientFactory, configuration, appSettings, logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _appSettings = appSettings.Value;
+        _logger = logger;
+        IntegrationMethod = IntegrationMethods.REST;
+    }
+
+    public override async Task<dynamic> GetAuthenticationAsync(
+        AppConfig config,
+        SCIMDirections direction = SCIMDirections.Outbound,
+        CancellationToken cancellationToken = default,
+        params dynamic[] args)
+    {
+        // Return cached token if still valid
+        if (_tokenCache.TryGetValue(config.AppId, out var cached) && cached.ExpiresAt > DateTime.UtcNow)
+        {
+            Log.Debug("Returning cached ApsToken for appId {AppId}.", config.AppId);
+            return cached.Token;
+        }
+
+        return await FetchAndCacheTokenAsync(config, cancellationToken);
+    }
+
+    protected new async Task<HttpClient> CreateHttpClientAsync(
+        AppConfig appConfig,
+        SCIMDirections direction,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await GetAuthenticationAsync(appConfig, direction, cancellationToken);
+        var client = _httpClientFactory.CreateClient();
+
+        // Tungsten requires: Authorization: ApsToken Value="<token>"
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("ApsToken", $"Value=\"{token}\"");
+
+        var customConfig = _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == appConfig.AppId);
+        if (customConfig?.HttpSettings?.Headers is { Count: > 0 })
+        {
+            client.SetCustomHeaders(customConfig.HttpSettings.Headers);
+        }
+
+        return client;
+    }
+
+    public override async Task<Core2EnterpriseUser?> ProvisionAsync(
+        dynamic payload,
+        AppConfig appConfig,
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        Log.Information("Tungsten user creation started. AppId: {AppId}, CorrelationID: {CorrelationID}",
+            appConfig.AppId, correlationId);
+
+        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Post
+            ?? throw new InvalidOperationException("User creation endpoint not configured.");
+
+        var organizationId = GetOrganizationId(appConfig.AppId);
+
+        JObject jPayload = payload as JObject ?? JObject.FromObject(payload);
+        jPayload["OrganizationId"] = organizationId;
+
+        var httpClient = await CreateHttpClientAsync(appConfig, SCIMDirections.Outbound, cancellationToken);
+        var content = new StringContent(jPayload.ToString(Formatting.None), System.Text.Encoding.UTF8, "application/json");
+        var response = await httpClient.PostAsync(userUri, content, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                InvalidateCache(appConfig.AppId);
+            }
+
+            Log.Error("Tungsten user creation failed. AppId: {AppId}, Status: {Status}, Response: {Response}",
+                appConfig.AppId, response.StatusCode, responseBody);
+            throw new System.Net.Http.HttpRequestException($"Error creating Tungsten user: {response.StatusCode} - {responseBody}");
+        }
+
+        var json = JObject.Parse(responseBody);
+        var userName = json["UserName"]?.ToString();
+
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            Log.Error("Tungsten create response missing UserName. AppId: {AppId}, Response: {Response}",
+                appConfig.AppId, responseBody);
+            throw new InvalidOperationException("Tungsten user creation response did not contain a UserName.");
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                Log.Information("Tungsten user created successfully. UserName: {UserName}, AppId: {AppId}, CorrelationID: {CorrelationID}",
+                    userName, appConfig.AppId, correlationId);
+
+                await CreateLogAsync(appConfig.AppId, "Create User",
+                    $"Tungsten user created successfully for UserName {userName}",
+                    LogType.Provision, LogSeverities.Information, correlationId);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to write audit log after Tungsten user creation. AppId: {AppId}", appConfig.AppId);
+            }
+        }, cancellationToken);
+
+        return new Core2EnterpriseUser { Identifier = userName };
+    }
+
+    public override async Task<Core2EnterpriseUser> GetAsync(
+        string identifier,
+        AppConfig appConfig,
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Get
+            ?? throw new InvalidOperationException("GET endpoint not configured.");
+
+        var organizationId = GetOrganizationId(appConfig.AppId);
+
+        var url = DynamicApiUrlUtil.GetFullUrl(userUri.ToString(), organizationId, identifier);
+        var client = await CreateHttpClientAsync(appConfig, SCIMDirections.Outbound, cancellationToken);
+        var response = await client.GetAsync(url, cancellationToken);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            throw new NotFoundException($"Tungsten user not found: {identifier}");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                InvalidateCache(appConfig.AppId);
+
+            Log.Error("Tungsten GET failed. Identifier: {Identifier}, AppId: {AppId}, Status: {Status}",
+                identifier, appConfig.AppId, response.StatusCode);
+            throw new System.Net.Http.HttpRequestException($"Tungsten GET failed: {response.StatusCode}");
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = JObject.Parse(responseBody);
+
+        _ = CreateLogAsync(appConfig.AppId, "Get User",
+            $"Tungsten user retrieved successfully for UserName {identifier}",
+            LogType.Read, LogSeverities.Information, correlationId);
+
+        return new Core2EnterpriseUser
+        {
+            Identifier = identifier,
+            // Store Tungsten GUID Id in ExternalId for use by Replace/Delete
+            ExternalIdentifier = json["Id"]?.ToString()
+        };
+    }
+
+    public override async Task ReplaceAsync(
+        dynamic payload,
+        Core2EnterpriseUser resource,
+        AppConfig appConfig,
+        string correlationId)
+    {
+        Log.Information("Tungsten user replace started. AppId: {AppId}, CorrelationID: {CorrelationID}",
+            appConfig.AppId, correlationId);
+
+        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Put
+            ?? throw new InvalidOperationException("PUT endpoint not configured.");
+
+        var organizationId = GetOrganizationId(appConfig.AppId);
+
+        // Resolve Tungsten GUID Id via GET (needed in PUT body)
+        var existing = await GetAsync(resource.Identifier, appConfig, correlationId);
+        var tungstenId = existing.ExternalIdentifier
+            ?? throw new InvalidOperationException($"Could not resolve Tungsten Id for user: {resource.Identifier}");
+
+        JObject jPayload = payload as JObject ?? JObject.FromObject(payload);
+        jPayload["Id"] = tungstenId;
+        jPayload["OrganizationId"] = organizationId;
+
+        var httpClient = await CreateHttpClientAsync(appConfig, SCIMDirections.Outbound, CancellationToken.None);
+        var content = new StringContent(jPayload.ToString(Formatting.None), System.Text.Encoding.UTF8, "application/json");
+        var response = await httpClient.PutAsync(userUri, content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                InvalidateCache(appConfig.AppId);
+
+            Log.Error("Tungsten user replace failed. AppId: {AppId}, Status: {Status}, Response: {Response}",
+                appConfig.AppId, response.StatusCode, responseBody);
+            throw new System.Net.Http.HttpRequestException($"Error replacing Tungsten user: {response.StatusCode} - {responseBody}");
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                Log.Information("Tungsten user replaced successfully. UserName: {UserName}, AppId: {AppId}, CorrelationID: {CorrelationID}",
+                    resource.Identifier, appConfig.AppId, correlationId);
+
+                await CreateLogAsync(appConfig.AppId, "Replace User",
+                    $"Tungsten user replaced successfully for UserName {resource.Identifier}",
+                    LogType.Provision, LogSeverities.Information, correlationId);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to write audit log after Tungsten user replace. AppId: {AppId}", appConfig.AppId);
+            }
+        });
+    }
+
+    public override async Task UpdateAsync(
+        dynamic payload,
+        Core2EnterpriseUser resource,
+        AppConfig appConfig,
+        string correlationId)
+    {
+        await ReplaceAsync(payload, resource, appConfig, correlationId);
+    }
+
+    public override async Task DeleteAsync(
+        string identifier,
+        AppConfig appConfig,
+        string correlationId)
+    {
+        Log.Information("Tungsten user delete started. AppId: {AppId}, CorrelationID: {CorrelationID}",
+            appConfig.AppId, correlationId);
+
+        var userUri = appConfig.UserURIs?.FirstOrDefault()?.Delete
+            ?? throw new InvalidOperationException("DELETE endpoint not configured.");
+
+        // Resolve Tungsten GUID Id via GET
+        var existing = await GetAsync(identifier, appConfig, correlationId);
+        var tungstenId = existing.ExternalIdentifier
+            ?? throw new InvalidOperationException($"Could not resolve Tungsten Id for user: {identifier}");
+
+        var url = DynamicApiUrlUtil.GetFullUrl(userUri.ToString(), tungstenId);
+        var httpClient = await CreateHttpClientAsync(appConfig, SCIMDirections.Outbound, CancellationToken.None);
+        var response = await httpClient.DeleteAsync(url);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                InvalidateCache(appConfig.AppId);
+
+            Log.Error("Tungsten user delete failed. AppId: {AppId}, Identifier: {Identifier}, Status: {Status}",
+                appConfig.AppId, identifier, response.StatusCode);
+            throw new System.Net.Http.HttpRequestException($"Error deleting Tungsten user: {response.StatusCode} - {responseBody}");
+        }
+
+        // DELETE returns 200 with the deleted entity body — log for audit
+        Log.Information("Tungsten user deleted successfully. UserName: {UserName}, AppId: {AppId}, CorrelationID: {CorrelationID}",
+            identifier, appConfig.AppId, correlationId);
+
+        _ = CreateLogAsync(appConfig.AppId, "Delete User",
+            $"Tungsten user deleted successfully for UserName {identifier}",
+            LogType.Provision, LogSeverities.Information, correlationId);
+    }
+
+    private async Task<string> FetchAndCacheTokenAsync(AppConfig config, CancellationToken cancellationToken)
+    {
+        var basicAuth = JsonConvert.DeserializeObject<BasicAuthentication>(config.AuthenticationDetails.ToString());
+
+        if (basicAuth is null || string.IsNullOrWhiteSpace(basicAuth.Username) || string.IsNullOrWhiteSpace(basicAuth.Password))
+            throw new InvalidOperationException(
+                $"Tungsten auth requires Username and Password in AuthenticationDetails (appId: {config.AppId}).");
+
+        var baseUrl = config.UserURIs?.FirstOrDefault()?.BaseUrl?.TrimEnd('/')
+            ?? throw new InvalidOperationException($"BaseUrl not configured in UserURIs for appId: {config.AppId}.");
+
+        var authUrl = $"{baseUrl}/authentication/rest/authenticate";
+
+        var requestBody = JsonConvert.SerializeObject(new
+        {
+            UserName = basicAuth.Username,
+            Password = basicAuth.Password,
+            AuthenticationType = 4
+        });
+
+        Log.Debug("Requesting Tungsten ApsToken for appId {AppId}.", config.AppId);
+
+        var client = _httpClientFactory.CreateClient();
+
+        // Apply fixed headers (x-rs-key, x-rs-version etc.) to the auth call too
+        var customConfig = _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == config.AppId);
+        if (customConfig?.HttpSettings?.Headers is { Count: > 0 })
+        {
+            client.SetCustomHeaders(customConfig.HttpSettings.Headers);
+        }
+
+        var response = await client.PostAsync(
+            authUrl,
+            new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json"),
+            cancellationToken);
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Log.Error("Tungsten authentication failed. AppId: {AppId}, Status: {Status}, Response: {Response}",
+                config.AppId, response.StatusCode, responseBody);
+            throw new AuthenticationException(
+                $"Tungsten authentication failed (appId: {config.AppId}). HTTP {(int)response.StatusCode}: {responseBody}");
+        }
+
+        var json = JObject.Parse(responseBody);
+        var token = json["Token"]?.ToString();
+
+        if (string.IsNullOrWhiteSpace(token))
+            throw new AuthenticationException($"Tungsten returned no Token for appId: {config.AppId}.");
+
+        _tokenCache[config.AppId] = (token, DateTime.UtcNow.AddMinutes(20));
+
+        Log.Debug("Tungsten ApsToken cached for appId {AppId}, expires in 20 minutes.", config.AppId);
+        return token;
+    }
+
+    private string GetOrganizationId(string appId)
+    {
+        return _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == appId)?.OrganizationId
+            ?? throw new InvalidOperationException($"OrganizationId not configured in AppIntegrationConfigs for appId: {appId}.");
+    }
+
+    private static void InvalidateCache(string appId)
+    {
+        _tokenCache.TryRemove(appId, out _);
+        Log.Warning("Tungsten ApsToken cache invalidated for appId {AppId} due to 401.", appId);
+    }
+}

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
@@ -28,6 +28,7 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly AppSettings _appSettings;
     private readonly IKloudIdentityLogger _logger;
+    private readonly IConfiguration _config;
 
     private static readonly ConcurrentDictionary<string, (string Token, DateTime ExpiresAt)> _tokenCache = new();
 
@@ -42,6 +43,7 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
         _httpClientFactory = httpClientFactory;
         _appSettings = appSettings.Value;
         _logger = logger;
+        _config = configuration;
         IntegrationMethod = IntegrationMethods.REST;
     }
 
@@ -73,11 +75,15 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
         client.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("ApsToken", $"Value=\"{token}\"");
 
+        // Apply fixed headers (x-rs-version, x-rs-culture, x-rs-uiculture) from AppIntegrationConfigs
         var customConfig = _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == appConfig.AppId);
         if (customConfig?.HttpSettings?.Headers is { Count: > 0 })
         {
             client.SetCustomHeaders(customConfig.HttpSettings.Headers);
         }
+
+        // x-rs-key is resolved from App Config Key Vault reference — applied separately
+        client.DefaultRequestHeaders.Add("x-rs-key", GetApiKey());
 
         return client;
     }
@@ -253,6 +259,12 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
         AppConfig appConfig,
         string correlationId)
     {
+        if (resource.UserName == null)
+        {
+            Log.Warning("UpdateAsync skipped for appId {AppId}: resource.UserName is null.", appConfig.AppId);
+            return;
+        }
+        
         await ReplaceAsync(payload, resource, appConfig, correlationId);
     }
 
@@ -320,12 +332,15 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
 
         var client = _httpClientFactory.CreateClient();
 
-        // Apply fixed headers (x-rs-key, x-rs-version etc.) to the auth call too
+        // Apply fixed headers (x-rs-version, x-rs-culture, x-rs-uiculture) to the auth call too
         var customConfig = _appSettings.AppIntegrationConfigs?.FirstOrDefault(x => x.AppId == config.AppId);
         if (customConfig?.HttpSettings?.Headers is { Count: > 0 })
         {
             client.SetCustomHeaders(customConfig.HttpSettings.Headers);
         }
+
+        // x-rs-key resolved from App Config Key Vault reference
+        client.DefaultRequestHeaders.Add("x-rs-key", GetApiKey());
 
         var response = await client.PostAsync(
             authUrl,
@@ -364,5 +379,11 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
     {
         _tokenCache.TryRemove(appId, out _);
         Log.Warning("Tungsten ApsToken cache invalidated for appId {AppId} due to 401.", appId);
+    }
+
+    private string GetApiKey()
+    {
+        return _config["KI:Tungsten:ApiKey"]
+            ?? throw new InvalidOperationException("Tungsten API key (KI:Tungsten:ApiKey) not configured in App Configuration.");
     }
 }

--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
@@ -105,6 +105,28 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
         JObject jPayload = payload as JObject ?? JObject.FromObject(payload);
         jPayload["OrganizationId"] = organizationId;
 
+        // Extract UserName from payload — needed for GET-first upsert check
+        var userName = jPayload["UserName"]?.ToString();
+        if (string.IsNullOrWhiteSpace(userName))
+            throw new InvalidOperationException("Payload must contain UserName for Tungsten provisioning.");
+
+        // Upsert: check if user already exists in Tungsten before creating
+        try
+        {
+            var existing = await GetAsync(userName, appConfig, correlationId, cancellationToken);
+            if (existing != null)
+            {
+                Log.Information("Tungsten user already exists, updating instead. UserName: {UserName}, AppId: {AppId}, CorrelationID: {CorrelationID}",
+                    userName, appConfig.AppId, correlationId);
+                await ReplaceAsync(jPayload, new Core2EnterpriseUser { Identifier = userName }, appConfig, correlationId);
+                return new Core2EnterpriseUser { Identifier = userName };
+            }
+        }
+        catch (NotFoundException)
+        {
+            // User does not exist in Tungsten — proceed with create below
+        }
+
         var httpClient = await CreateHttpClientAsync(appConfig, SCIMDirections.Outbound, cancellationToken);
         var content = new StringContent(jPayload.ToString(Formatting.None), System.Text.Encoding.UTF8, "application/json");
         var response = await httpClient.PostAsync(userUri, content, cancellationToken);
@@ -123,7 +145,7 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
         }
 
         var json = JObject.Parse(responseBody);
-        var userName = json["UserName"]?.ToString();
+        userName = json["UserName"]?.ToString();
 
         if (string.IsNullOrWhiteSpace(userName))
         {

--- a/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
+++ b/KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs
@@ -77,6 +77,7 @@ public static class ServiceExtension
         services.AddScoped<IIntegrationBase, LinuxIntegration>();
         services.AddScoped<IIntegrationBase, AS400Integration>();
         services.AddScoped<IIntegrationBase, SQLIntegration>();
+        services.AddScoped<IIntegrationBase, TungstenAPEssentialsIntegration>();
 
         services.AddScoped<IIntegrationBaseFactory, IntegrationBaseFactory>();
 

--- a/Microsoft.SCIM.WebHostSample/appsettings.json
+++ b/Microsoft.SCIM.WebHostSample/appsettings.json
@@ -15,7 +15,7 @@
   "urnPrefix": "urn:kn:ki:schema:",
   "MgtPortalUrl": "https://api-ki-mgtportal.azurewebsites.net",
   "Database": {
-    "AuthMode": "Entra"
+    "AuthMode": "Sql"
   },
   "RabbitMQ": {
     "QueueName_In": "scimsvc-in",
@@ -24,7 +24,8 @@
   "IntegrationMappings": {
     "AppIdToIntegration": {
       "Navitaire": "RESTIntegrationV2",
-      "pnb001": "RestIntegrationManageEngine"
+      "pnb001": "RestIntegrationManageEngine",
+      "tungstenapessentials": "TungstenAPEssentialsIntegration"
     },
     "DefaultIntegration": {
       "REST": "RESTIntegration",


### PR DESCRIPTION
This pull request introduces the Tungsten AP Essentials (ReadSoft Online) integration into KloudIdentity as a new REST-based provisioning method. It includes all necessary configuration, service registration, and documentation to support the integration, following best practices for authentication, token caching, and payload mapping. No changes to authentication strategies or domain models are required; the integration is fully encapsulated in a new class and configuration wiring.

**Tungsten AP Essentials Integration**

- Added a comprehensive implementation plan and technical documentation for integrating Tungsten AP Essentials, detailing authentication, endpoints, payloads, and rationale. (`.github/prompts/plan-118-tungsten-ap-essentials-integration.md`)
- Introduced a new integration class, `TungstenAPEssentialsIntegration`, registered in DI for use as an `IIntegrationBase` implementation. (`KN.KloudIdentity.Mapper/Utils/ServiceExtension.cs`)
- Updated application configuration to map the new Tungsten integration by AppId. (`Microsoft.SCIM.WebHostSample/appsettings.json`)

**Configuration and Domain Model Updates**

- Extended the `AppIntegrationConfig` domain model to include an `OrganizationId` property, required for Tungsten API calls. (`KN.KloudIdentity.Mapper.Domain/Shared/AppSettings.cs`)

**Developer and Tooling Support**

- Added a `CLAUDE.md` file to guide AI code assistants (Claude) on project structure, build/test commands, and key architectural patterns.
- Created a `.claude/settings.json` file to specify command permissions for Claude Code.

**Other Configuration**

- Changed the database authentication mode in `appsettings.json` from `Entra` to `Sql` (likely for local development/testing). (`Microsoft.SCIM.WebHostSample/appsettings.json`)
[Copilot is generating a summary...]