### PR TITLE
feat: Update user extraction logic in TungstenAPEssentialsIntegration…

### DIFF
--- a/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
+++ b/KN.KloudIdentity.Mapper/MapperCore/IntegrationMethods/Tug/TungstenAPEssentialsIntegration.cs
@@ -107,7 +107,7 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
         jPayload["OrganizationId"] = organizationId;
 
         // Extract UserName from payload — needed for GET-first upsert check
-        var userName = jPayload["UserName"]?.ToString();
+        var userName = jPayload ["UserToCreate"]?["UserName"]?.ToString();
         if (string.IsNullOrWhiteSpace(userName))
             throw new InvalidOperationException("Payload must contain UserName for Tungsten provisioning.");
 
@@ -119,7 +119,7 @@ public class TungstenAPEssentialsIntegration : RESTIntegration
             {
                 Log.Information("Tungsten user already exists, updating instead. UserName: {UserName}, AppId: {AppId}, CorrelationID: {CorrelationID}",
                     userName, appConfig.AppId, correlationId);
-                await ReplaceAsync(jPayload, new Core2EnterpriseUser { Identifier = userName }, appConfig, correlationId);
+               // await ReplaceAsync(jPayload, new Core2EnterpriseUser { Identifier = userName }, appConfig, correlationId);
                 return new Core2EnterpriseUser { Identifier = userName };
             }
         }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Core2EnterpriseUserExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Core2EnterpriseUserExtensions.cs
@@ -16,9 +16,7 @@ namespace Microsoft.SCIM
         public static void Apply(this Core2EnterpriseUser user, PatchRequest2Base<PatchOperation2> patch)
         {
             if (null == user)
-            {
                 throw new ArgumentNullException(nameof(user));
-            }
 
             if (null == patch)
             {
@@ -995,11 +993,12 @@ namespace Microsoft.SCIM
             if (user.PhoneNumbers != null)
             {
                 phoneNumberExisting =
-                    phoneNumber =
-                        user
-                            .PhoneNumbers
-                            .SingleOrDefault((PhoneNumber item) =>
-                                string.Equals(subAttribute.ComparisonValue, item.ItemType, StringComparison.Ordinal));
+                    user
+                        .PhoneNumbers
+                        .SingleOrDefault((PhoneNumber item) =>
+                            string.Equals(subAttribute.ComparisonValue, item.ItemType, StringComparison.Ordinal));
+
+                phoneNumber = phoneNumberExisting ?? new PhoneNumber() { ItemType = subAttribute.ComparisonValue };
             }
             else
             {


### PR DESCRIPTION
This pull request introduces targeted changes to user provisioning logic and patch operations, primarily focusing on how usernames are extracted from payloads and how phone numbers are handled during patching. It also includes a minor code cleanup for argument validation.

**User provisioning and patch logic updates:**

* Changed extraction of `UserName` in `TungstenAPEssentialsIntegration.cs` to read from the nested `UserToCreate` object in the payload, ensuring correct username retrieval for Tungsten provisioning.
* Commented out the call to `ReplaceAsync` when a Tungsten user already exists, which may affect the update flow for existing users.

**Patch operation improvements:**

* In `Core2EnterpriseUserExtensions.cs`, fixed the logic for patching phone numbers so that a new `PhoneNumber` object is created if one matching the `ItemType` does not already exist, preventing null reference issues.

**Code cleanup:**

* Removed unnecessary braces around the `ArgumentNullException` throw for the `user` parameter in `Apply`, simplifying the code.